### PR TITLE
Fixed create_slice method to return urls with the start and end values

### DIFF
--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -195,8 +195,8 @@ def _create_slices(chunk_size, id, referenceName, start, end):
         _create_slice(urls, id, referenceName, slice_start, end)
     else:  # One slice only
         url = f"http://{request.host}{BASE_PATH}/data/{id}"
-        if referenceName is not None:
-            url += f"?referenceName={referenceName}"
+        if referenceName and start and end:
+            url += f"?referenceName={referenceName}&start={start}&end={end}"
         urls.append({"url": url})
 
     return urls
@@ -340,7 +340,7 @@ def get_data(id, referenceName=None, format=None, start=None, end=None):
                 index_filename=index_file
             )
 
-        file_out = AlignmentFile(ntf.name, 'w', header=file_in.header)
+        file_out = AlignmentFile(ntf.name, 'wb', header=file_in.header)
 
     for rec in file_in.fetch(contig=referenceName, start=start, end=end):
         file_out.write(rec)

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -267,7 +267,7 @@ def get_variants(id, referenceName=None, start=None, end=None):
     return response, http_status_code
 
 
-def get_data(id, referenceName=None, format=None, start=None, end=None):
+def get_data(id, referenceName=None, format="bam", start=None, end=None):
     # start = 17148269, end = 17157211, referenceName = 21
     """
     Returns the specified variant or read file:
@@ -340,7 +340,14 @@ def get_data(id, referenceName=None, format=None, start=None, end=None):
                 index_filename=index_file
             )
 
-        file_out = AlignmentFile(ntf.name, 'wb', header=file_in.header)
+        if format == "bam":
+            format = "wb"
+        elif format == "sam":
+            format = "w"
+        else:
+            return "Invalid format.", 400
+
+        file_out = AlignmentFile(ntf.name, format, header=file_in.header)
 
     for rec in file_in.fetch(contig=referenceName, start=start, end=end):
         file_out.write(rec)

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -274,6 +274,7 @@ def get_data(id, referenceName=None, format="bam", start=None, end=None):
 
     :param id: id of the file ( e.g. id=HG02102 for file HG02102.vcf.gz )
     :param referenceName: Chromesome Number
+    :param format: Format of output ( e.g bam, sam)
     :param start: Index of file to begin at
     :param end: Index of file to end at
     """

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -289,6 +289,9 @@ def get_data(id, referenceName=None, format="bam", start=None, end=None):
     if referenceName == "None":
         referenceName = None
 
+    if format not in ["bam", "sam"]:
+        return "Invalid format.", 400
+
     file_name = ""
     file_format = ""
     file_in_path = ""
@@ -340,14 +343,12 @@ def get_data(id, referenceName=None, format="bam", start=None, end=None):
                 index_filename=index_file
             )
 
-        if format == "bam":
-            format = "wb"
-        elif format == "sam":
-            format = "w"
+        if format == "sam":
+            output_format = "w"
         else:
-            return "Invalid format.", 400
+            output_format = "wb"
 
-        file_out = AlignmentFile(ntf.name, format, header=file_in.header)
+        file_out = AlignmentFile(ntf.name, output_format, header=file_in.header)
 
     for rec in file_in.fetch(contig=referenceName, start=start, end=end):
         file_out.write(rec)

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -332,9 +332,6 @@ def get_data(id, referenceName=None, format="bam", start=None, end=None):
 
         file_out = VariantFile(ntf.name, 'w', header=file_in.header)
     elif file_format == "BAM" or file_format == "CRAM":  # Reads
-        referenceName = referenceName.lower().replace("chr", "").upper()
-        if not referenceName.isnumeric() and referenceName not in ["X", "Y"]:
-            return "Invalid Reference Name", 400
 
         if FILE_RETRIEVAL == "db":
             file_in = AlignmentFile(file_in_path)
@@ -351,7 +348,13 @@ def get_data(id, referenceName=None, format="bam", start=None, end=None):
 
         file_out = AlignmentFile(ntf.name, output_format, header=file_in.header)
 
-    for rec in file_in.fetch(contig=referenceName, start=start, end=end):
+    try:
+        fetch = file_in.fetch(contig=referenceName, start=start, end=end)
+    except ValueError:
+        referenceName = referenceName.lower().replace("chr", "").upper()
+        fetch = file_in.fetch(contig=referenceName, start=start, end=end)
+
+    for rec in fetch:
         file_out.write(rec)
 
     file_in.close()

--- a/htsget_server/server.py
+++ b/htsget_server/server.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_cors import CORS
 import connexion
 import configparser
 
@@ -7,6 +8,7 @@ config.read('./config.ini')
 
 # Create the application instance
 app = connexion.App(__name__, specification_dir='./')
+CORS(app.app)
 
 app.add_api('swagger.yaml')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==1.1.2
+Flask-Cors==3.0.9
 minio==6.0.0
 Connexion==2.7.0
 ga4gh-dos-schemas==0.4.2


### PR DESCRIPTION
This PR fixes the` create_slice` method to return URLs with the start and end values