### PR TITLE
Precise region search

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,8 @@ export OPA_SECRET=$(cat /run/secrets/opa-service-token)
 
 if [[ -f "initial_setup" ]]; then
     if [[ -f "/run/secrets/cert.pem" ]]; then
-        cat /run/secrets/cert.pem >> /usr/local/lib/python3.7/site-packages/certifi/cacert.pem
+        SITE_PKGS=`python -c 'import site; print(site.getsitepackages()[0])'`
+        cat /run/secrets/cert.pem >> ${SITE_PKGS}/site-packages/certifi/cacert.pem
     fi
 
     sed -i s@\<CANDIG_OPA_SECRET\>@$OPA_SECRET@ config.ini
@@ -22,7 +23,7 @@ if [[ -f "initial_setup" ]]; then
     crontab cron_bkp
     rm cron_bkp
     
-    sqlite3 ${DB_PATH:-/app/htsget_server/data/files.db} -init /app/htsget_server/data/files.sql 
+    sqlite3 ${DB_PATH:-/app/htsget_server/data/files.db} -init /app/htsget_server/data/files.sql "SELECT * from variantfile"
     rm initial_setup
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,14 @@ export OPA_SECRET=$(cat /run/secrets/opa-service-token)
 
 if [[ -f "initial_setup" ]]; then
     if [[ -f "/run/secrets/cert.pem" ]]; then
-        SITE_PKGS=`python -c 'import site; print(site.getsitepackages()[0])'`
-        cat /run/secrets/cert.pem >> ${SITE_PKGS}/site-packages/certifi/cacert.pem
+        CERT=$(head -n 2 /run/secrets/cert.pem | tail -n 1)
+        SITE_PKGS=$(python -c 'import site; print(site.getsitepackages()[0])')
+        echo $SITE_PKGS
+        if grep -q "$CERT" $SITE_PKGS/certifi/cacert.pem
+        then
+            echo "hi"
+            cat /run/secrets/cert.pem >> ${SITE_PKGS}/certifi/cacert.pem
+        fi
     fi
 
     sed -i s@\<CANDIG_OPA_SECRET\>@$OPA_SECRET@ config.ini

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -17,6 +17,8 @@ def is_authed(id_, request):
         print("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         app.logger.warning("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         return 200 # no auth
+    if is_site_admin(request):
+        return 200
     if "Authorization" in request.headers:
         authed_datasets = get_authorized_datasets(request)
         obj, code2 = drs_operations.get_object(id_)
@@ -32,6 +34,13 @@ def is_authed(id_, request):
     else:
         return 401
     return 403
+
+
+def is_testing(request):
+    if request.headers.get("Test_Key") == TEST_KEY:
+        print("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
+        app.logger.warning("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
+        return True
 
 
 def get_authorized_datasets(request):

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -763,9 +763,10 @@ def get_variant_count_for_variantfile(obj):
     with Session() as session:
         vfile = aliased(VariantFile)
         q = select(vfile.drs_object_id, PositionBucket.id, PositionBucket.pos_bucket_id, PositionBucketVariantFileAssociation.bucket_count).select_from(PositionBucket).join(PositionBucketVariantFileAssociation).where(vfile.drs_object_id == PositionBucketVariantFileAssociation.variantfile_id).where(vfile.drs_object_id == obj['id'])
-        contig_id = normalize_contig(obj['referenceName'])
-        q = q.where(PositionBucket.contig_id == contig_id)
-        if 'start' in obj:
+        if 'referenceName' in obj and obj['referenceName'] is not None:
+            contig_id = normalize_contig(obj['referenceName'])
+            q = q.where(PositionBucket.contig_id == contig_id)
+        if 'start' in obj and obj['start'] > 0:
             q = q.where(PositionBucket.pos_bucket_id >= obj['start'])
         if 'end' in obj and obj['end'] != -1:
             q = q.where(PositionBucket.pos_bucket_id < obj['end'])

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -820,9 +820,9 @@ def search(obj):
                 else:
                     return {"error": "no referenceName specified"}
                 if 'start' in region:
-                    q = q.where(PositionBucket.pos_bucket_id >= region['start'])
+                    q = q.where(PositionBucket.pos_bucket_id >= get_bucket_for_position(region['start']))
                 if 'end' in region:
-                    q = q.where(PositionBucket.pos_bucket_id < region['end'])
+                    q = q.where(PositionBucket.pos_bucket_id <= get_bucket_for_position(region['end']))
         q = q.distinct()
         result = {
             'drs_object_ids': [],

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -9,7 +9,7 @@ import drs_operations
 import database
 import authz
 import json
-from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE
+from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT
 from markupsafe import escape
 import connexion
 
@@ -350,10 +350,13 @@ def _get_data(id_, reference_name=None, start=None, end=None, class_="body", for
     return { "message": "no object matching id found" }, 404
     
     
-def _get_base_url(file_type, id, data=False):
+def _get_base_url(file_type, id, data=False, testing=False):
+    url = HTSGET_URL
+    if authz.is_testing(request):
+        url = os.getenv("TESTENV_URL", f"http://localhost:{PORT}")
     if data:
-        return f"{HTSGET_URL}/htsget/v1/{file_type}s/data/{id}"
-    return f"{HTSGET_URL}/htsget/v1/{file_type}s/{id}"
+        return f"{url}/htsget/v1/{file_type}s/data/{id}"
+    return f"{url}/htsget/v1/{file_type}s/{id}"
   
 def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=None):
     """

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -172,7 +172,7 @@ def search_variants():
         if len(req.json['regions']) > 1:
             return {"message": "Only one region at a time is searchable for now."}, 400
         region = req.json['regions'][0]
-        ref_name = region['referenceName']
+        ref_name = database.normalize_contig(region['referenceName'])
         if 'start' in region:
             start = region['start']
         if 'end' in region:

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -174,7 +174,9 @@ def search_variants():
         region = req.json['regions'][0]
         ref_name = database.normalize_contig(region['referenceName'])
         if 'start' in region:
-            start = region['start']
+            start = region['start'] - 1
+            if start < 0:
+                start = 0
         if 'end' in region:
             end = region['end']
     searchresult = database.search(req.json)

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -196,7 +196,7 @@ def search_variants():
             result['results'].append(htsget_obj)
     # This is a good coarse search result, but what if the region is smaller than a bucket? 
     # We should actually grab all of the data from the drs_objects in question and count.
-    if (end - start <= BUCKET_SIZE):
+    if end is not None and start is not None and (end - start <= BUCKET_SIZE):
         fine_results = []
         for obj in result['results']:
             gen_obj = _get_genomic_obj(obj['id'])

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -232,6 +232,22 @@ def test_search_variantfile(body, count):
     print(response.text)
     assert len(response.json()["results"]) == count
 
+
+def test_search_snp():
+    url = f"{HOST}/htsget/v1/variants/search"
+    body = {
+            'regions': [
+                {
+                    'referenceName': 'chr21',
+                    'start': 48060904,
+                    'end': 48060904
+                }
+            ]
+        }
+    response = requests.post(url, json=body, headers=headers)
+    print(response.text)
+    assert len(response.json()["results"]) == 6
+
 @pytest.fixture
 def drs_objects():
     return [

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -133,7 +133,8 @@ def test_existent_file(id, expected_status):
 def test_pull_slices_data():
     return [
         ({"referenceName": "20",
-          "start": 0, "end": 1260000}, 'sample.compressed', ".vcf.gz", "variant")
+          "start": 0, "end": 1260000}, 'sample.compressed', ".vcf.gz", "variant"),
+        ({}, 'sample.compressed', ".vcf.gz", "variant")
     ]
 
 
@@ -170,7 +171,11 @@ def test_pull_slices(params, id_, file_extension, file_type):
             f_index = rec.pos - 1
             break
         # compare slice and file line by line
-        for x, y in zip(f_slice.fetch(), f.fetch(contig=params['referenceName'], start=f_index)):
+        if 'referenceName' in params:
+          zipped = zip(f_slice.fetch(), f.fetch(contig=params['referenceName'], start=f_index))
+        else:
+          zipped = zip(f_slice.fetch(), f.fetch())
+        for x, y in zipped:
             if x != y:
                 equal = False
                 assert equal

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -239,7 +239,7 @@ def test_search_snp():
             'regions': [
                 {
                     'referenceName': 'chr21',
-                    'start': 48062672,
+                    'start': 48062673,
                     'end': 48062673
                 }
             ]

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -10,7 +10,7 @@ from pathlib import Path
 sys.path.insert(0,os.path.abspath("htsget_server"))
 from config import PORT, LOCAL_FILE_PATH
 
-HOST = f"http://localhost:{PORT}"
+HOST = os.getenv("TESTENV_URL", f"http://localhost:{PORT}")
 TEST_KEY = os.environ.get("HTSGET_TEST_KEY")
 CWD = os.getcwd()
 headers={"Test_Key": TEST_KEY, "Authorization": "Bearer testtest"}

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -254,9 +254,11 @@ def drs_objects():
   {
     "access_methods": [
       {
-        "access_id": "play.min.io:9000/testhtsget/NA18537.vcf.gz.tbi",
-        "type": "s3",
-        "region": "us-east-1"
+        "access_url": {
+          "headers": [],
+          "url": f"file://{CWD}/data/files/NA18537.vcf.gz.tbi"
+        },
+        "type": "file"
       }
     ],
     "aliases": [],
@@ -274,9 +276,11 @@ def drs_objects():
   {
     "access_methods": [
       {
-        "access_id": "play.min.io:9000/testhtsget/NA18537.vcf.gz",
-        "type": "s3",
-        "region": "us-east-1"
+        "access_url": {
+          "headers": [],
+          "url": f"file://{CWD}/data/files/NA18537.vcf.gz"
+        },
+        "type": "file"
       }
     ],
     "aliases": [],
@@ -392,8 +396,11 @@ def drs_objects():
   {
     "access_methods": [
       {
-        "access_id": "play.min.io:9000/testhtsget/NA20787.vcf.gz.tbi",
-        "type": "s3"
+        "access_url": {
+          "headers": [],
+          "url": f"file://{CWD}/data/files/NA20787.vcf.gz.tbi"
+        },
+        "type": "file"
       }
     ],
     "aliases": [],
@@ -411,8 +418,11 @@ def drs_objects():
   {
     "access_methods": [
       {
-        "access_id": "play.min.io:9000/testhtsget/NA20787.vcf.gz",
-        "type": "s3"
+        "access_url": {
+          "headers": [],
+          "url": f"file://{CWD}/data/files/NA20787.vcf.gz"
+        },
+        "type": "file"
       }
     ],
     "aliases": [],

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -239,14 +239,14 @@ def test_search_snp():
             'regions': [
                 {
                     'referenceName': 'chr21',
-                    'start': 48060904,
-                    'end': 48060904
+                    'start': 48062672,
+                    'end': 48062673
                 }
             ]
         }
     response = requests.post(url, json=body, headers=headers)
     print(response.text)
-    assert len(response.json()["results"]) == 6
+    assert len(response.json()["results"]) == 1
 
 @pytest.fixture
 def drs_objects():


### PR DESCRIPTION
One can now search for a single SNP. There is a new test in test_htsget_server.py that tests for a single SNP that is only in one of the test files and it passes.

```
def test_search_snp():
    url = f"{HOST}/htsget/v1/variants/search"
    body = {
            'regions': [
                {
                    'referenceName': 'chr21',
                    'start': 48062672,
                    'end': 48062673
                }
            ]
        }
    response = requests.post(url, json=body, headers=headers)
    print(response.text)
    assert len(response.json()["results"]) == 1
```