### PR TITLE
Tiny fixes that slipped through

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 Port = 3000
 BasePath = /htsget/v1
 ChunkSize = 1000000
-BucketSize = 1000
+BucketSize = 10000
 
 [paths]
 LocalFilesPath = ./data/files

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -611,7 +611,7 @@ def get_samples_in_drs_objects(obj):
     # obj = {'drs_object_ids'}
     with Session() as session:
         result = []
-        q = select(Sample.sample_id).where(Sample.variantfile_id.in_(obj['drs_object_ids'])).distinct()
+        q = select(Sample.sample_id).where(Sample.variantfile_id.in_(set(obj['drs_object_ids']))).distinct()
         for row in session.execute(q):
             result.append(str(row._mapping['sample_id']))
         return result
@@ -850,7 +850,7 @@ def search(obj):
         ref_genomes = {}
         for rgv in rgvs:
             ref_genomes[rgv.id] = rgv.reference_genome
-        bvs = session.query(PositionBucketVariantFileAssociation).where(PositionBucketVariantFileAssociation.pos_bucket_id.in_(pos_bucket_ids), PositionBucketVariantFileAssociation.variantfile_id.in_(drs_obj_ids)).order_by(PositionBucketVariantFileAssociation.variantfile_id).order_by(PositionBucketVariantFileAssociation.pos_bucket_id).all()
+        bvs = session.query(PositionBucketVariantFileAssociation).where(PositionBucketVariantFileAssociation.pos_bucket_id.in_(set(pos_bucket_ids)), PositionBucketVariantFileAssociation.variantfile_id.in_(set(drs_obj_ids))).order_by(PositionBucketVariantFileAssociation.variantfile_id).order_by(PositionBucketVariantFileAssociation.pos_bucket_id).all()
         if bvs is not None:
             for bv in bvs:
                 result['raw'].append(str(bv))

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -505,7 +505,7 @@ def create_variantfile(obj):
         if new_variantfile is None:
             new_variantfile = VariantFile()
             new_variantfile.indexed = 0
-            new_variantfile.chr_prefix = '0'
+            new_variantfile.chr_prefix = ''
         new_variantfile.id = obj['id']
         if "genomic_id" in obj:
             new_variantfile.genomic_id = obj['genomic_id']

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -175,8 +175,8 @@ class PositionBucket(ObjectDBBase):
 
 class Sample(ObjectDBBase):
     __tablename__ = 'sample'
-    id = Column(Integer, primary_key=True)
-    sample_id = Column(String, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    sample_id = Column(String)
     
     # a sample is in a single variantfile
     variantfile_id = Column(String, ForeignKey('variantfile.id'))

--- a/htsget_server/operations.py
+++ b/htsget_server/operations.py
@@ -206,7 +206,11 @@ def search_variants():
         fine_results = []
         for obj in result['results']:
             gen_obj = _get_genomic_obj(obj['id'])
-            actual = gen_obj['file'].fetch(contig=ref_name, start=start, end=end)
+            orig_ref_name = database.get_contig_name_in_variantfile({'refname': ref_name, 'variantfile_id': obj['id']})
+            try:
+                actual = gen_obj['file'].fetch(contig=orig_ref_name, start=start, end=end)
+            except Exception as e:
+                return {"message": str(e)}, 500
             actual_count = sum(1 for _ in actual)
             if (actual_count > 0):
                 obj['variantcount'] = actual_count


### PR DESCRIPTION
While testing on dev, I noticed that one of the pytest tests failed that I could've sworn I fixed! Turns out this was a lingering branch that I'd started after demo but never managed to make into a PR. So here it is.

* Larger bucket size speeds up indexing and tests.
* There was a complaint in the logs about not marking something as autoincrement, so I did.
* Chr_prefix actually needs to be used correctly to fetch from files.
* Converting giant arrays to sets will remove dups so that the actual queries are shorter.