### PR TITLE
DIG-1002: Integration testing for htsget/minio

### DIFF
--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -26,7 +26,7 @@ def get_headers():
         token = get_access_token(username=USERNAME, password=PASSWORD)
         print("got token")
         headers["Authorization"] = f"Bearer {token}"
-    except:
+    except Exception as e:
         headers["Authorization"] = "Bearer testtest"
     return headers
 

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -30,6 +30,18 @@ def get_headers():
         headers["Authorization"] = "Bearer testtest"
     return headers
 
+
+def test_remove_objects(drs_objects):
+    headers = get_headers()
+    for obj in drs_objects:
+        url = f"{HOST}/ga4gh/drs/v1/objects/{obj['id']}"
+        response = requests.request("GET", url, headers=headers)
+        if response.status_code == 200:
+            response = requests.request("DELETE", url, headers=headers)
+            print(f"DELETE {obj['name']}: {response.text}")
+            assert response.status_code == 200
+
+
 def test_post_objects(drs_objects):
     """
     Install test objects. Will fail if any post request returns an error.
@@ -57,11 +69,6 @@ def test_post_objects(drs_objects):
 
     for obj in drs_objects:
         url = f"{HOST}/ga4gh/drs/v1/objects/{obj['id']}"
-        response = requests.request("GET", url, headers=headers)
-        if response.status_code == 200:
-            response = requests.request("DELETE", url, headers=headers)
-            print(f"DELETE {obj['name']}: {response.text}")
-            assert response.status_code == 200
         if "contents" not in obj:
             # create access_methods:
             obj["access_methods"] = [
@@ -82,6 +89,7 @@ def test_post_objects(drs_objects):
         response = requests.request("POST", url, json=obj, headers=headers)
         print(f"POST {obj['name']}: {response.text}")
         assert response.status_code == 200
+
 
 def test_post_update():
     id = "NA18537.vcf.gz.tbi"


### PR DESCRIPTION
Set env vars using env.sh:
```
cd CanDIGv2/
python settings.py
source env.sh
```

You should be able to export an extra variable `export TESTENV_URL=http://docker.localhost:3333` and then run pytest from the `lib/htsget-server/htsget_app` directory. That will use the docker stack's local Minio instance to store files and retrieve them; this exercises the integration between htsget, minio, vault, and the auth methods.