### PR TITLE
Beacon tweaks

### DIFF
--- a/data/files.sql
+++ b/data/files.sql
@@ -14,12 +14,6 @@ CREATE TABLE drs_object (
         aliases VARCHAR,
         PRIMARY KEY (id)
 );
-INSERT INTO drs_object VALUES('NA18537.vcf.gz.tbi','NA18537.vcf.gz.tbi','drs://localhost/NA18537.vcf.gz.tbi',0,'2021-09-27T18:40:00.538843','2021-09-27T18:40:00.539022','v1','application/octet-stream','[]','','[]');
-INSERT INTO drs_object VALUES('NA18537.vcf.gz','NA18537.vcf.gz','drs://localhost/NA18537.vcf.gz',0,'2021-09-27T18:40:00.538843','2021-09-27T18:40:00.539022','v1','application/octet-stream','[]','','[]');
-INSERT INTO drs_object VALUES('NA18537','NA18537','drs://localhost/NA18537',0,'2021-09-27T18:40:00.538843','2021-09-27T18:40:00.539022','v1','application/octet-stream','[]','','[]');
-INSERT INTO drs_object VALUES('NA20787.vcf.gz.tbi','NA20787.vcf.gz.tbi','drs://localhost/NA20787.vcf.gz.tbi',0,'2021-09-27T18:58:56.663378','2021-09-27T18:58:56.663442','v1','application/octet-stream','[]','','[]');
-INSERT INTO drs_object VALUES('NA20787.vcf.gz','NA20787.vcf.gz','drs://localhost/NA20787.vcf.gz',0,'2021-09-27T18:58:56.663378','2021-09-27T18:58:56.663442','v1','application/octet-stream','[]','','[]');
-INSERT INTO drs_object VALUES('NA20787','NA20787','drs://localhost/NA20787',0,'2021-09-27T18:58:56.663378','2021-09-27T18:58:56.663442','v1','application/octet-stream','[]','','[]');
 CREATE TABLE access_method (
         id INTEGER NOT NULL,
         drs_object_id INTEGER,
@@ -31,10 +25,6 @@ CREATE TABLE access_method (
         PRIMARY KEY (id),
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-INSERT INTO access_method VALUES(1,'NA18537.vcf.gz.tbi','s3','s3.amazonaws.com/daisietestbucket1/test/NA18537.vcf.gz.tbi','','','[]');
-INSERT INTO access_method VALUES(2,'NA18537.vcf.gz','s3','s3.amazonaws.com/daisietestbucket1/test/NA18537.vcf.gz','','','[]');
-INSERT INTO access_method VALUES(3,'NA20787.vcf.gz.tbi','s3','s3.amazonaws.com/daisietestbucket1/test/NA20787.vcf.gz.tbi','','','[]');
-INSERT INTO access_method VALUES(4,'NA20787.vcf.gz','s3','s3.amazonaws.com/daisietestbucket1/test/NA20787.vcf.gz','','','[]');
 CREATE TABLE content_object (
         id INTEGER NOT NULL,
         drs_object_id INTEGER,
@@ -44,15 +34,10 @@ CREATE TABLE content_object (
         PRIMARY KEY (id),
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-INSERT INTO content_object VALUES(1,'NA18537','NA18537.vcf.gz','["drs://localhost/NA18537.vcf.gz"]','[]');
-INSERT INTO content_object VALUES(2,'NA18537','NA18537.vcf.gz.tbi','["drs://localhost/NA18537.vcf.gz.tbi"]','[]');
-INSERT INTO content_object VALUES(5,'NA20787','NA20787.vcf.gz','["drs://localhost/NA20787.vcf.gz"]','[]');
-INSERT INTO content_object VALUES(6,'NA20787','NA20787.vcf.gz.tbi','["drs://localhost/NA20787.vcf.gz.tbi"]','[]');
 CREATE TABLE dataset (
 	id VARCHAR NOT NULL,
 	PRIMARY KEY (id)
 );
-INSERT INTO dataset VALUES('controlled4');
 CREATE TABLE dataset_association (
 	dataset_id VARCHAR NOT NULL,
 	drs_object_id VARCHAR NOT NULL,
@@ -60,7 +45,6 @@ CREATE TABLE dataset_association (
 	FOREIGN KEY(dataset_id) REFERENCES dataset (id),
 	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-INSERT INTO dataset_association VALUES('controlled4','NA18537');
 CREATE TABLE contig (
 	id VARCHAR NOT NULL,
 	PRIMARY KEY (id)

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -265,18 +265,17 @@ def search(raw_req):
             response['responseSummary']['exists'] = True
 
         # if the request granularity was "record", check to see that the user is actually authorized to see any datasets:
-        datasets, status_code = drs_operations.list_datasets()
-        if len(datasets) > 0 and raw_req['requestedGranularity'] == 'record':
+        response['beaconHandovers'] = []
+        for drs_obj in variants_by_file.keys():
+            handover, status_code = htsget_operations.get_variants(id_=drs_obj, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+            if handover is not None:
+                handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
+                response['beaconHandovers'].append(handover)
+        if len(response['beaconHandovers']) > 0:
             response['response'] = resultset
-            # add handovers:
-            response['beaconHandovers'] = []
-            for drs_obj in variants_by_file.keys():
-                handover, status_code = htsget_operations.get_variants(id_=drs_obj, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
-                if handover is not None:
-                    handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
-                    response['beaconHandovers'].append(handover)
         else:
             meta['returnedGranularity'] = 'count'
+            response.pop('beaconHandovers')
     else:
         response = {
             'error': {

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -271,9 +271,10 @@ def search(raw_req):
             # add handovers:
             response['beaconHandovers'] = []
             for drs_obj in variants_by_file.keys():
-                handover = htsget_operations._get_htsget_url(drs_obj, actual_params['reference_name'], actual_params['start'], actual_params['end'], 'variant', data=False)
-                handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
-                response['beaconHandovers'].append(handover)
+                handover, status_code = htsget_operations.get_variants(id_=drs_obj, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+                if handover is not None:
+                    handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
+                    response['beaconHandovers'].append(handover)
         else:
             meta['returnedGranularity'] = 'count'
     else:

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -211,6 +211,8 @@ def search(raw_req):
             actual_params['start'] = allele_loc['start']
             actual_params['end'] = allele_loc['end']
             # actual_params['type'] = allele_loc['type']
+            if 'reference_genome' in allele_loc:
+                actual_params['reference_genome'] = allele_loc['reference_genome']
             if 'ref' in allele_loc:
                 actual_params['ref'] = allele_loc['ref']
             if 'alt' in allele_loc:

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -260,8 +260,9 @@ def convert_hgvsid_to_location(hgvsid, reference_genome='hg38'):
                 result['start'] = int(gene['start']) + int(hgvs_parse.group(2))
                 break
         else:
-            # this is a chromosome
+            # this is a chromosome; these belong to only one reference genome
             result['reference_name'] = database.normalize_contig(genes[0]['contig'])
+            result['reference_genome'] = genes[0]['reference_genome']
             result['start'] = int(hgvs_parse.group(2))
 
         # parse allele bit, group(3):


### PR DESCRIPTION
Tiny tweaks to fix problems I didn't notice until writing integration tests:

1) Chromosome RefSeqs are tied to particular reference genome builds, so if we get one of those in the allele short form request, we already know what the reference genome is, even if it's not specified otherwise. (this isn't true for other RefSeq transcripts: they can be named the same across reference genomes)

If you run a request on something like "http://docker.localhost:5080/genomics/beacon/v2/g_variants?allele=NC_000021.8%3Ag.5030847T%3EA", you should see the reference genome in the request parameters:
```
      "requestParameters": {
        "alt": "A",
        "end": 5030848,
        "genomic_allele_short_form": "NC_000021.8:g.5030847T>A",
        "ref": "T",
        "reference_genome": "hg37",
        "reference_name": "21",
        "start": 5030847
      },
```

2) If a user doesn't have access to a particular file, they shouldn't get the htsget link in the handovers either. This is a bit harder to test until I commit the integration tests. It is a pretty small change, though.