### PR TITLE
Fixes to allow pytest to run inside the container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@ set -Euo pipefail
 
 export VAULT_S3_TOKEN=$(cat /run/secrets/vault-s3-token)
 export OPA_SECRET=$(cat /run/secrets/opa-service-token)
+export VAULT_URL=$CANDIG_VAULT_URL
 
 if [[ -f "initial_setup" ]]; then
     if [[ -f "/run/secrets/cert.pem" ]]; then

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -52,18 +52,29 @@ def test_post_objects(drs_objects):
     headers = get_headers()
     response = requests.request("GET", url, headers=headers)
 
-    client = None
+    # in case we're running on the container itself, which might have secrets
+    try:
+        with open("/run/secrets/minio-access-key", "r") as f:
+            minio_access_key = f.read().strip()
+    except Exception as e:
+        minio_access_key = MINIO_ACCESS_KEY
+    try:
+        with open("/run/secrets/minio-secret-key", "r") as f:
+            minio_secret_key = f.read().strip()
+    except Exception as e:
+        minio_secret_key = MINIO_SECRET_KEY
 
+    client = None
     try:
         bucket = 'testhtsget'
-        if MINIO_URL and MINIO_ACCESS_KEY and MINIO_SECRET_KEY:
+        if MINIO_URL and minio_access_key and minio_secret_key:
             if VAULT_URL:
                 token = get_access_token(username=USERNAME, password=PASSWORD)
-                credential, status_code = store_aws_credential(token=token, endpoint=MINIO_URL, bucket=bucket, access=MINIO_ACCESS_KEY, secret=MINIO_SECRET_KEY, vault_url=VAULT_URL)
+                credential, status_code = store_aws_credential(token=token, endpoint=MINIO_URL, bucket=bucket, access=minio_access_key, secret=minio_secret_key, vault_url=VAULT_URL)
                 if status_code == 200:
                     client = get_minio_client(token=token, s3_endpoint=credential["endpoint"], bucket=bucket)
             else:
-                client = get_minio_client(token=None, s3_endpoint=MINIO_URL, bucket=bucket, access_key=MINIO_ACCESS_KEY, secret_key=MINIO_SECRET_KEY)
+                client = get_minio_client(token=None, s3_endpoint=MINIO_URL, bucket=bucket, access_key=minio_access_key, secret_key=minio_secret_key)
         if client is None:
             client = get_minio_client(bucket=bucket)
     except Exception as e:
@@ -76,8 +87,8 @@ def test_post_objects(drs_objects):
         if "contents" not in obj:
             # create access_methods:
             access_id = f"{client['endpoint']}/{client['bucket']}/{obj['id']}"
-            if VAULT_URL is None and MINIO_ACCESS_KEY and MINIO_SECRET_KEY:
-                access_id += f"?access={MINIO_ACCESS_KEY}&secret={MINIO_SECRET_KEY}"
+            if VAULT_URL is None and minio_access_key and minio_secret_key:
+                access_id += f"?access={minio_access_key}&secret={minio_secret_key}"
             obj["access_methods"] = [
                 {
                     "type": "s3",


### PR DESCRIPTION
If someone were to want to run pytest inside the container, it would be nice if it worked. We need to be able to get the Minio access key and secret key from the secrets files.

Test this from https://github.com/CanDIG/CanDIGv2/pull/213, making sure you've pulled this branch before testing there.