### PR TITLE
DIG-932: Add uwsgi production deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 
 env:
-  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=data/files.db
+  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=data/files.db SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data
 
 before_install:
   - docker pull minio/minio

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ RUN apk add --no-cache \
 	bzip2-dev \
 	xz-dev \
 	libcurl \
+	linux-headers \
 	curl \
 	curl-dev \
 	yaml-dev \
 	libressl-dev \
+	pcre-dev \
 	git \
 	sqlite
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ LABEL "candigv2"="htsget_app"
 
 USER root
 
+RUN addgroup -S candig && adduser -S candig -G candig
+
 RUN apk update
 
 RUN apk add --no-cache \

--- a/create_db.sh
+++ b/create_db.sh
@@ -12,6 +12,7 @@ sqlite3 -bail $db "SELECT * from ncbiRefSeq limit 1"
 if [[ $? -eq 1 ]]; then
     echo "initializing database..."
     sqlite3 $db -init data/files.sql "SELECT * from variantfile"
+    chown -R candig:candig $(dirname $db)
     echo "...done"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,4 +34,9 @@ if [[ -f "initial_setup" ]]; then
 fi
 
 crond
-python3 htsget_server/server.py $@
+
+# use the following for development
+#python3 htsget_server/server.py
+
+# use the following instead for production deployment
+uwsgi uwsgi.ini

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -2,6 +2,7 @@ import connexion
 import database
 from flask import request, Flask
 import os
+import os.path
 import re
 import authz
 from markupsafe import escape
@@ -231,9 +232,13 @@ def _get_file_path(drs_file_obj_id):
             url_pieces = urlparse(method["access_url"]["url"])
             if url_pieces.scheme == "file":
                 if url_pieces.netloc == "" or url_pieces.netloc == "localhost":
-                    result["path"] = url_pieces.path.lstrip("/")
+                    result["path"] = os.path.abspath(url_pieces.path)
+                    if not os.path.exists(result["path"]):
+                        result['message'] = f"No file exists at {result['path']} on the server."
+                        result['status_code'] = 404
     if result['path'] is None:
         result['message'] = f"No file was found for drs_obj {drs_file_obj_id}: {url}"
+        result['status_code'] = 404
         result.pop('path')
     return result
 

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -338,7 +338,7 @@ def _get_data(id_, reference_name=None, start=None, end=None, class_=None, forma
     gen_obj = drs_operations._get_genomic_obj(id_)
     if gen_obj is not None:
         if "message" in gen_obj:
-            return gen_obj['message'], gen_obj['status_code']
+            return {"message": gen_obj['message']}, gen_obj['status_code']
         file_in = gen_obj["file"]
         ntf = tempfile.NamedTemporaryFile(prefix='htsget', suffix=format_,
                                  mode='wb', delete=False)

--- a/htsget_server/wsgi.py
+++ b/htsget_server/wsgi.py
@@ -1,0 +1,4 @@
+from server import app
+
+if __name__ == "__main__":
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ connexion==2.14.1
 MarkupSafe==2.1.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v1.0.0
 pytest==7.2.0
+uwsgi==2.0.21

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -9,6 +9,7 @@ from authx.auth import get_minio_client, get_access_token, store_aws_credential
 REPO_DIR = os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/..")
 sys.path.insert(0, os.path.abspath(f"{REPO_DIR}/htsget_server"))
 LOCAL_FILE_PATH = os.path.abspath(f"{REPO_DIR}/data/files")
+SERVER_LOCAL_DATA = os.getenv("SERVER_LOCAL_DATA", "/app/htsget_server/data")
 from config import PORT
 
 HOST = os.getenv("TESTENV_URL", f"http://localhost:{PORT}")
@@ -126,7 +127,7 @@ def test_post_update():
     obj = response.json()
 
     url = f"{HOST}/ga4gh/drs/v1/objects"
-    access_url = f"file:////app/htsget_server/data/files/NA18537.vcf.gz" # this is local within the htsget server container, not from where we're running pytest
+    access_url = f"file:///{SERVER_LOCAL_DATA}/files/NA18537.vcf.gz" # this is local within the htsget server container, not from where we're running pytest
     obj["access_methods"] = [
         {
             "type": "file",

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -126,7 +126,7 @@ def test_post_update():
     obj = response.json()
 
     url = f"{HOST}/ga4gh/drs/v1/objects"
-    access_url = f"file:///./data/files/NA18537.vcf.gz" # this is local within the htsget server container, not from where we're running pytest
+    access_url = f"file:////app/htsget_server/data/files/NA18537.vcf.gz" # this is local within the htsget server container, not from where we're running pytest
     obj["access_methods"] = [
         {
             "type": "file",

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,9 @@
+[uwsgi]
+module = wsgi:app
+chdir = htsget_server
+http = 0.0.0.0:3000
+
+master = true
+processes = 4
+
+harakiri = 30

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,4 +6,7 @@ http = 0.0.0.0:3000
 master = true
 processes = 4
 
+gid = candig
+uid = candig
+
 harakiri = 30


### PR DESCRIPTION
I added a simple uwsgi configuration to the server. `make test-integration` should still work (except for possibly katsu tests, but that's unrelated).

While moving relative locations around, I realized that it was untenable to try to deal with not-absolute local file paths in access methods, so I added some error catching for that and updated the test.