### PR TITLE
DIG-1252: add submitter_sample_id information to genomic drs objects

### DIFF
--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -864,7 +864,7 @@ components:
                 description: Reference to the bioinformatics analysis ID (`analysis.id`)
                 type: string
               biosampleId:
-                description: Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}/{submitter_sample_id}`, delimited with a slash. If this is not available, it will be the name of the sample as listed in the variant file.
+                description: Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}~{submitter_sample_id}`, delimited with a slash. If this is not available, it will be the name of the sample as listed in the variant file.
                 type: string
               clinicalInterpretations:
                 items:

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -864,7 +864,7 @@ components:
                 description: Reference to the bioinformatics analysis ID (`analysis.id`)
                 type: string
               biosampleId:
-                description: Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}~{submitter_sample_id}`, delimited with a slash. If this is not available, it will be the name of the sample as listed in the variant file.
+                description: Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}~{submitter_sample_id}`, delimited with a tilde. If this is not available, it will be the name of the sample as listed in the variant file.
                 type: string
               clinicalInterpretations:
                 items:

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -864,7 +864,7 @@ components:
                 description: Reference to the bioinformatics analysis ID (`analysis.id`)
                 type: string
               biosampleId:
-                description: Reference to biosample ID (`biosample.id`)
+                description: Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}/{submitter_sample_id}`, delimited with a slash. If this is not available, it will be the name of the sample as listed in the variant file.
                 type: string
               clinicalInterpretations:
                 items:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -418,13 +418,13 @@ components:
             = f7a29a04
         contents:
           type: array
-          description: The specific genomic contents objects that comprise this genomic DRS entity. Should contain a GenomicDataContentsObject and an optional GenomicIndexContentsObject.
+          description: The specific genomic contents objects that comprise this genomic DRS entity. Should contain a GenomicDataContentsObject, an optional GenomicIndexContentsObject, and SampleContentsObjects corresponding to the samples analyzed in the genomic data object.
           minItems: 1
           items:
             anyOf:
-              - $ref: '#/components/schemas/SampleContentsObject'
               - $ref: '#/components/schemas/GenomicDataContentsObject'
               - $ref: '#/components/schemas/GenomicIndexContentsObject'
+              - $ref: '#/components/schemas/SampleContentsObject'
         description:
           type: string
           description: A human readable description of the `DrsObject`.
@@ -709,7 +709,7 @@ components:
           description: The submitter_sample_id of the sample in the MoH model
         id:
           type: string
-          description: The id corresponding to the SampleDrsObject
+          description: The id of the SampleDrsObject, corresponding to the sample's name in the VCF file
         drs_uri:
           type: array
           description: The DRS uri(s) to the SampleDrsObject

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -349,7 +349,7 @@ components:
             accession numbers or external GUIDs.
     GenomicDrsObject:
       type: object
-      description: A DrsObject that describes a bundled genomic data entity. It usually will consist of a genomic data file, e.g. a variant or read file, and its associated index file.
+      description: A DrsObject that describes a bundled genomic data entity. It usually will consist of a genomic data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Samples (as SampleContentObjects), ordered in order of appearance in the associated variant/read files.
       required:
         - id
         - contents

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -422,6 +422,7 @@ components:
           minItems: 1
           items:
             anyOf:
+              - $ref: '#/components/schemas/SampleContentsObject'
               - $ref: '#/components/schemas/GenomicDataContentsObject'
               - $ref: '#/components/schemas/GenomicIndexContentsObject'
         description:
@@ -695,6 +696,24 @@ components:
         drs_uri:
           type: array
           description: The DRS uri(s) to the GenomicDrsObject
+          items:
+            type: string
+    SampleContentsObject:
+      type: object
+      required:
+        - name
+        - id
+      properties:
+        name:
+          type: string
+          description: The submitter_sample_id of the sample in the MoH model
+        id:
+          type: string
+          enum:
+            - sample
+        drs_uri:
+          type: array
+          description: The DRS uri(s) to the SampleDrsObject
           items:
             type: string
     GenomicDataContentsObject:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -709,8 +709,7 @@ components:
           description: The submitter_sample_id of the sample in the MoH model
         id:
           type: string
-          enum:
-            - sample
+          description: The id corresponding to the SampleDrsObject
         drs_uri:
           type: array
           description: The DRS uri(s) to the SampleDrsObject

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -163,6 +163,8 @@ def _get_genomic_obj(object_id):
         if 'message' in main_result:
             result = main_result
         else:
+            if "samples" in drs_obj:
+                result['samples'] = drs_obj['samples']
             try:
                 result['file_format'] = drs_obj['format']
                 if drs_obj['type'] == 'read':
@@ -182,7 +184,7 @@ def _describe_drs_object(object_id):
     result = {
         "name": object_id
     }
-    # drs_obj should have two contents objects
+    # drs_obj should have a main contents, index contents, and sample contents
     if "contents" in drs_obj:
         for contents in drs_obj["contents"]:
             # get each drs object (should be the genomic file and its index)
@@ -205,6 +207,11 @@ def _describe_drs_object(object_id):
                 result['main'] = contents['name']
             elif index_match is not None:
                 result['index'] = contents['name']
+            else:
+                if "samples" not in result:
+                    result['samples'] = {}
+                result['samples'][contents['id']] = contents['name']
+
     if 'type' not in result:
         return {"message": f"drs object {object_id} does not represent an htsget object", "status_code": 404}
     return result

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -67,7 +67,10 @@ def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
     for r in records:
         samples = []
         for s in r.samples:
-            samples.append(s)
+            if "samples" in gen_obj and s in gen_obj['samples']:
+                samples.append(gen_obj['samples'][s])
+            else:
+                samples.append(s)
         variant_record = parse_variant_record(str(r), samples, variants_by_file['info'])
         variants_by_file['variants'].append(variant_record)
     return variants_by_file

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -210,7 +210,7 @@ def get_ingest_sample_names(genomic_id):
         ingest_map, program_id = item
         if ingest_map["genomic_id"] == genomic_id:
             for sample in ingest_map["samples"]:
-                result[sample['sample_name_in_file']] = f"{program_id}/{sample['sample_registration_id']}"
+                result[sample['sample_name_in_file']] = f"{program_id}~{sample['sample_registration_id']}"
     return result
 
 
@@ -228,7 +228,7 @@ def test_add_sample_drs(input, program_id):
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
     for sample in input['samples']:
-        sample_id = f"{program_id}/{sample['sample_registration_id']}"
+        sample_id = f"{program_id}~{sample['sample_registration_id']}"
         # remove any existing objects:
         sample_url = f"{HOST}/ga4gh/drs/v1/objects/{sample_id}"
         response = requests.request("GET", sample_url, headers=headers)

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -442,6 +442,15 @@ def test_beacon_post_search(body, count, cases):
     assert len(response.json()['response']) == count
     assert len(response.json()['response'][0]['caseLevelData']) == cases
 
+    # check to see if the sample names got in:
+    samples = get_ingest_sample_names('multisample_1')
+    for cld in response.json()['response'][0]['caseLevelData']:
+        if cld['analysisId'] == 'multisample_1':
+            assert cld['biosampleId'] in samples.values()
+        else:
+            assert cld['biosampleId'] not in samples.values()
+
+
 # if we search for NBPF1, we should find records in test.vcf that contain NBPF1 in their VEP annotations.
 def test_beacon_search_annotations():
     url = f"{HOST}/beacon/v2/g_variants"

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -307,41 +307,41 @@ def test_beacon_get_search():
 
 
 def get_beacon_post_search():
-        return [
-            (
-                # 6 variations, corresponding to three variant records in multisample_1 and multisample_2
-                # first variation, corresponding to "NC_000021.8:g.5030551=", should contain two cases
-                {
-                    "query": {
-                        "requestParameters": {
-                            "start": [5030000],
-                            "end": [5030847],
-                            "assemblyId": "hg37",
-                            "referenceName": "21"
-                        }
-                    },
-                    "meta": {
-                        "apiVersion": "v2"
+    return [
+        (
+            # 6 variations, corresponding to three variant records in multisample_1 and multisample_2
+            # first variation, corresponding to "NC_000021.8:g.5030551=", should contain two cases
+            {
+                "query": {
+                    "requestParameters": {
+                        "start": [5030000],
+                        "end": [5030847],
+                        "assemblyId": "hg37",
+                        "referenceName": "21"
                     }
-                }, 6, 2
-            ),
-            (
-                # 5 variations, corresponding to 2 refs and 3 alts in test
-                # first variation has two cases
-                {
-                    "query": {
-                        "requestParameters": {
-                            "start": [16562322],
-                            "end": [16613564],
-                            "referenceName": "1"
-                        }
-                    },
-                    "meta": {
-                        "apiVersion": "v2"
+                },
+                "meta": {
+                    "apiVersion": "v2"
+                }
+            }, 6, 2
+        ),
+        (
+            # 5 variations, corresponding to 2 refs and 3 alts in test
+            # first variation has two cases
+            {
+                "query": {
+                    "requestParameters": {
+                        "start": [16562322],
+                        "end": [16613564],
+                        "referenceName": "1"
                     }
-                }, 5, 2
-            )
-        ]
+                },
+                "meta": {
+                    "apiVersion": "v2"
+                }
+            }, 5, 2
+        )
+    ]
 
 
 @pytest.mark.parametrize('body, count, cases', get_beacon_post_search())


### PR DESCRIPTION
I had misunderstood the connection between SampleDrsObjects and the MoH model in https://github.com/CanDIG/htsget_app/pull/261. I thought that we were mapping a single clinical ID, like a donor ID, to a genomic data object. In fact, though, the linkage is more granular than that: a genomic data object can have several samples in it, and each of those samples corresponds to a specific SampleRegistration in the MoH data model.

I've updated the DRS model: SampleDrsObjects contain SampleContentsObjects, instead of GenomicContentsObjects. The SampleContentsObject represents the link between a SampleDrsObject and a GenomicDrsObject. For example, a GenomicDrsObject that represents a VCF variant file will have contents consisting of its associated GenomicDataContentsObject, GenomicIndexContentsObject, and as many SampleContentsObject as map to the samples in the VCF file.

This means that in drs_operations, _get_genomic_obj and _describe_drs_obj will include a sample mapping, if available. This dict maps the sample names found in the genomic data object to any corresponding submitter_sample_ids, if they were provided as part of the genomic drs object.

I updated test_htsget_server to include a mapping of fake sample_registration_ids to the samples in multisample_1, and a test to verify that it works in a beacon search.

After running pytest, you can see the result by running 
```
## beacon POST
curl -X "POST" "http://candig.docker.internal:5080/genomics/beacon/v2/g_variants" \
     -H 'Authorization: Bearer <site admin token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "query": {
    "requestParameters": {
      "assemblyId": "hg37",
      "referenceName": "21",
      "end": [
        5030847
      ],
      "start": [
        5030000
      ]
    }
  },
  "meta": {
    "apiVersion": "v2"
  }
}'
```

You should get results that have case level data for multisample_1 and multisample_2. The biosampleIds for the ones with analysisId `multisample_1` will have biosampleIds like `SYNTHETIC-2/SAMPLE_REGISTRATION_3`, but the ones for `multisample_2` will still say `TUMOR` or `NORMAL`, as they do in the VCF file.