### PR TITLE
change base image from alpine to python-debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,18 @@
 ARG venv_python
-ARG alpine_version
-FROM python:${venv_python}-alpine${alpine_version}
+FROM python:${venv_python}
 
 LABEL Maintainer="CanDIG Project"
 LABEL "candigv2"="htsget_app"
 
 USER root
 
-RUN addgroup -S candig && adduser -S candig -G candig
+RUN useradd -r candig -U
 
-RUN apk update
-
-RUN apk add --no-cache \
-	autoconf \
-	automake \
-	make \
-	gcc \
-	perl \
-	bash \
-	build-base \
-	musl-dev \
-	zlib-dev \
-	bzip2-dev \
-	xz-dev \
-	libcurl \
-	linux-headers \
-	curl \
-	curl-dev \
-	yaml-dev \
-	libressl-dev \
-	pcre-dev \
-	git \
-	sqlite
+RUN apt-get update && apt-get -y install \
+	cron \
+	libpcre3  \
+	libpcre3-dev \
+	sqlite3
 
 COPY requirements.txt /app/htsget_server/requirements.txt
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ if [[ -f "initial_setup" ]]; then
     rm initial_setup
 fi
 
-crond
+cron
 
 # use the following for development
 #python3 htsget_server/server.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ MarkupSafe==2.1.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v1.0.0
 pytest==7.2.0
 uwsgi==2.0.21
+connexion[swagger-ui]


### PR DESCRIPTION
Changing the base image from alpine to the default Python image (which is Debian-based). This greatly speeds up the build time due to not having to re-compile the python wheels. 