### PR TITLE
DIG-1301: Delete genomic data

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -512,10 +512,13 @@ def create_dataset(obj):
 
 def delete_dataset(dataset_id):
     with Session() as session:
-        new_object = session.query(Dataset).filter_by(id=dataset_id).one()
-        session.delete(new_object)
+        dataset_objs = session.query(Dataset).filter_by(id=dataset_id).all()
+        for dataset_obj in dataset_objs:
+            for drs_obj in dataset_obj.associated_drs:
+                session.delete(drs_obj)
+            session.delete(dataset_obj)
         session.commit()
-        return json.loads(str(new_object))
+        return json.loads(str(dataset_objs))
 
 
 def list_refseqs(reference_genome="hg38"):

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -168,7 +168,7 @@ paths:
     delete:
       summary: Delete a dataset.
       description: >-
-        Returns object metadata, and a list of access methods that can be used to fetch object bytes.
+        Delete a dataset, and all associated DRS objects.
       operationId: drs_operations.delete_dataset
       responses:
           200:


### PR DESCRIPTION
# Related ticket
[DIG-1301](https://candig.atlassian.net/browse/DIG-1301)

# Description
Unsure if this was the entire ticket, but this change cascades a delete dataset call to also delete the DRS objects associated with that dataset. I'm unsure of the following (draft until this is answered):
1. Is there a method of creating DRS objects that are associated with a dataset but that don't update the "associated_drs" property? I don't see a method of adding DRS objects to a dataset, other than at the time you create the dataset.
2. Should I keep or delete the actual `.vcf`/`.bam` file? It was my understanding that HTSGet's not really responsible for the actual storage of the genomic data itself, so it wouldn't make sense imo for HTSGet to delete the data.

## Behaviour before this PR
(after running `make test-integration`):
```
(candig) 12:32 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X DELETE "http://candig.docker.internal:3333/ga4gh/drs/v1/datasets/SYNTHETIC-2" -H "Authorization: Bearer $TOKEN"
{
  "drsobjects": [
    "drs://candig.docker.internal:5080/genomics/NA20787",
    "drs://candig.docker.internal:5080/genomics/multisample_2"
  ],
  "id": "SYNTHETIC-2"
}
(candig) 12:33 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X GET "http://candig.docker.internal:3333/ga4gh/drs/v1/objects/NA20787" -H "Authorization: Bearer $TOKEN"
{
  "aliases": [],
  "checksums": [],
  "contents": [
    {
      "drs_uri": [
        "drs://candig.docker.internal:3333/NA20787.vcf.gz.tbi"
      ],
      "id": "index",
      "name": "NA20787.vcf.gz.tbi"
    },
    {
      "drs_uri": [
        "drs://candig.docker.internal:3333/NA20787.vcf.gz"
      ],
      "id": "variant",
      "name": "NA20787.vcf.gz"
    }
  ],
  "created_time": "2023-09-20T13:11:55.881313",
  "datasets": [],
  "description": "",
  "id": "NA20787",
  "mime_type": "application/octet-stream",
  "name": "NA20787",
  "self_uri": "drs://candig.docker.internal:5080/genomics/NA20787",
  "size": 0,
  "updated_time": "2023-09-20T13:11:55.881336",
  "version": "v1"
}
```

## Behaviour after this PR
```
(candig) 13:22 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X DELETE "http://candig.docker.internal:3333/ga4gh/drs/v1/datasets/SYNTHETIC-2" -H "Authorization: Bearer $TOKEN"
[
  {
    "drsobjects": [
      "drs://candig.docker.internal:5080/genomics/NA20787",
      "drs://candig.docker.internal:5080/genomics/multisample_2"
    ],
    "id": "SYNTHETIC-2"
  }
]
(candig) 13:22 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl -X GET "http://candig.docker.internal:3333/ga4gh/drs/v1/objects/NA20787" -H "Authorization: Bearer $TOKEN"
{
  "message": "No matching object found"
}
```

[DIG-1301]: https://candig.atlassian.net/browse/DIG-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ