### PR TITLE
DIG-1308 Switch HTSGet to Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ services:
   - docker
 
 env:
-  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=data/files.db SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data
+  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=data/files.db SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin
 
 before_install:
   - docker pull minio/minio
   - docker create -p9090:9090 -p9000:9000 -p9001:9001 minio/minio minio server /data | xargs -I{} docker start {}
+  - docker pull postgres:15-alpine
+  - docker create -p5433:5432  --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password postgres:15-alpine --name metadata-db | xargs -I{} docker start {}
   - docker ps -a
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - docker pull minio/minio
   - docker create -p9090:9090 -p9000:9000 -p9001:9001 minio/minio minio server /data | xargs -I{} docker start {}
   - docker pull postgres:15-alpine
-  - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password --name metadata-db postgres:15-alpine | xargs -I{} docker start {}
+  - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env POSTGRES_PASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password --name metadata-db postgres:15-alpine | xargs -I{} docker start {}
   - docker ps -a
   - docker logs metadata-db
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ services:
   - docker
 
 env:
-  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=data/files.db SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin
+  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=localhost SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin
 
 before_install:
   - docker pull minio/minio
   - docker create -p9090:9090 -p9000:9000 -p9001:9001 minio/minio minio server /data | xargs -I{} docker start {}
   - docker pull postgres:15-alpine
-  - docker create -p5433:5432  --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password postgres:15-alpine --name metadata-db | xargs -I{} docker start {}
+  - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password postgres:15-alpine --name metadata-db | xargs -I{} docker start {}
   - docker ps -a
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ before_install:
   - docker pull minio/minio
   - docker create -p9090:9090 -p9000:9000 -p9001:9001 minio/minio minio server /data | xargs -I{} docker start {}
   - docker pull postgres:15-alpine
-  - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password postgres:15-alpine --name metadata-db | xargs -I{} docker start {}
+  - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password --name metadata-db postgres:15-alpine | xargs -I{} docker start {}
   - docker ps -a
+  - docker logs metadata-db
 
 cache: pip
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apt-get update && apt-get -y install \
 	cron \
 	libpcre3  \
 	libpcre3-dev \
-	sqlite3
+	sqlite3 \
+	postgresql-client \
+    postgresql
 
 COPY requirements.txt /app/htsget_server/requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Thank you to [gel-htsget](https://github.com/genomicsengland/gel-htsget) for bei
 
 ## Stack
 - [Connexion](https://github.com/zalando/connexion) for implementing the API
-- [Sqlite3](https://www.sqlite.org/index.html)
+- [PostgreSQL](https://www.postgresql.org/)
 - [ga4gh Data-Repository-Service(DRS)](https://github.com/ga4gh/data-repository-service-schemas)
 - [minio-py](https://github.com/minio/minio-py)
 - [Flask](http://flask.pocoo.org/)

--- a/config.ini
+++ b/config.ini
@@ -6,6 +6,7 @@ BucketSize = 10000
 
 [paths]
 DBPath = sqlite:///./data/files.db
+PGPath = postgresql+psycopg2://admin:PASSWORD@metadata-db:5432/genomic
 
 [authz]
 CANDIG_OPA_SECRET = <CANDIG_OPA_SECRET>

--- a/config.ini
+++ b/config.ini
@@ -6,7 +6,7 @@ BucketSize = 10000
 
 [paths]
 DBPath = sqlite:///./data/files.db
-PGPath = postgresql+psycopg2://admin:PASSWORD@metadata-db:5432/genomic
+PGPath = postgresql+psycopg2://admin:PASSWORD@HOST:5432/genomic
 
 [authz]
 CANDIG_OPA_SECRET = <CANDIG_OPA_SECRET>

--- a/create_db.sh
+++ b/create_db.sh
@@ -3,11 +3,11 @@
 set -Euo pipefail
 
 # db=${DB_PATH:-data/files.db}
-db="metadata-db"
+db=${DB_PATH:-"metadata-db"}
 
 # PGPASSWORD is used by psql to avoid the password prompt
-export PGPASSWORD=`cat /run/secrets/metadata-db-secret`
-export PGUSER=`cat /run/secrets/metadata-db-user`
+export PGPASSWORD=${PGPASSWORD:-`cat /run/secrets/metadata-db-secret`}
+export PGUSER=${PGUSER:-`cat /run/secrets/metadata-db-user`}
 
 until pg_isready -h metadata-db -p 5432 -U $PGUSER; do
   echo "Waiting for the database to be ready..."
@@ -18,22 +18,22 @@ echo "database is at $db"
 pwd
 
 # initialize the db if it's not already there:
-psql --quiet -h $db -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
+psql --quiet -h "$db" -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
 if [[ $? -ne 0 ]]; then
     echo "initializing database..."
-    createdb -h $db -U $PGUSER genomic
-    psql --quiet -h $db -U $PGUSER -a -d genomic -f data/files.sql
+    createdb -h "$db" -U $PGUSER genomic
+    psql --quiet -h "$db" -U $PGUSER -a -d genomic -f data/files.sql
     echo "...done"
 fi
 
 # if the refseq table isn't filled in the database already, make it:
-numgenes=$(psql --quiet -h $db -U $PGUSER -d genomic -c "select * from ncbirefseq where gene_name != '' limit 1;" | wc -l)
+numgenes=$(psql --quiet -h "$db" -U $PGUSER -d genomic -c "select * from ncbirefseq where gene_name != '' limit 1;" | wc -l)
 if [[ $numgenes -lt 5 ]]; then
     echo "adding data to ncbirefseq..."
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
 
-    psql --quiet -h $db -U $PGUSER -d genomic -a -f genes.sql
+    psql --quiet -h "$db" -U $PGUSER -d genomic -a -f genes.sql
     # rm genes.sql
     echo "...done"
 fi

--- a/create_db.sh
+++ b/create_db.sh
@@ -10,7 +10,7 @@ export PGPASSWORD=${PGPASSWORD:-`cat /run/secrets/metadata-db-secret`}
 export PGUSER=${PGUSER:-`cat /run/secrets/metadata-db-user`}
 
 until pg_isready -h "$db" -p 5432 -U $PGUSER; do
-  echo "Waiting for the database to be ready..."
+  echo "Waiting for the database at $db to be ready..."
   sleep 1
 done
 

--- a/create_db.sh
+++ b/create_db.sh
@@ -18,22 +18,22 @@ echo "database is at $db"
 pwd
 
 # initialize the db if it's not already there:
-psql -h $db -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
+psql --quiet -h $db -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
 if [[ $? -ne 0 ]]; then
     echo "initializing database..."
     createdb -h $db -U $PGUSER genomic
-    psql -h $db -U $PGUSER -a -d genomic -f data/files.sql
+    psql --quiet -h $db -U $PGUSER -a -d genomic -f data/files.sql
     echo "...done"
 fi
 
 # if the refseq table isn't filled in the database already, make it:
-numgenes=$(psql -h $db -U $PGUSER -d genomic -c 'select * from ncbiRefSeq where gene_name != "" limit 1;' | wc -l)
-if [[ $numgenes -eq 0 ]]; then
-    echo "adding data to ncbiRefSeq..."
-    awk '{ print "INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
-    awk '{ print "INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
+numgenes=$(psql --quiet -h $db -U $PGUSER -d genomic -c "select * from ncbirefseq where gene_name != '' limit 1;" | wc -l)
+if [[ $numgenes -lt 5 ]]; then
+    echo "adding data to ncbirefseq..."
+    awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
+    awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
 
-    psql -h $db -U $PGUSER -d genomic -a -f genes.sql
-    rm genes.sql
+    psql --quiet -h $db -U $PGUSER -d genomic -a -f genes.sql
+    # rm genes.sql
     echo "...done"
 fi

--- a/create_db.sh
+++ b/create_db.sh
@@ -2,28 +2,38 @@
 
 set -Euo pipefail
 
-db=${DB_PATH:-data/files.db}
+# db=${DB_PATH:-data/files.db}
+db="metadata-db"
+
+# PGPASSWORD is used by psql to avoid the password prompt
+export PGPASSWORD=`cat /run/secrets/metadata-db-secret`
+export PGUSER=`cat /run/secrets/metadata-db-user`
+
+until pg_isready -h metadata-db -p 5432 -U $PGUSER; do
+  echo "Waiting for the database to be ready..."
+  sleep 1
+done
 
 echo "database is at $db"
 pwd
 
 # initialize the db if it's not already there:
-sqlite3 -bail $db "SELECT * from ncbiRefSeq limit 1"
-if [[ $? -eq 1 ]]; then
+psql -h $db -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
+if [[ $? -ne 0 ]]; then
     echo "initializing database..."
-    sqlite3 $db -init data/files.sql "SELECT * from variantfile"
-    chown -R candig:candig $(dirname $db)
+    createdb -h $db -U $PGUSER genomic
+    psql -h $db -U $PGUSER -a -d genomic -f data/files.sql
     echo "...done"
 fi
 
 # if the refseq table isn't filled in the database already, make it:
-numgenes=$(sqlite3 -bail $db 'select * from ncbiRefSeq where gene_name != "" limit 1;' | wc -l)
+numgenes=$(psql -h $db -U $PGUSER -d genomic -c 'select * from ncbiRefSeq where gene_name != "" limit 1;' | wc -l)
 if [[ $numgenes -eq 0 ]]; then
     echo "adding data to ncbiRefSeq..."
-    awk '{ print "INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047);"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
-    awk '{ print "INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047);"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
+    awk '{ print "INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
+    awk '{ print "INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
 
-    sqlite3 $db < genes.sql
+    psql -h $db -U $PGUSER -d genomic -a -f genes.sql
     rm genes.sql
     echo "...done"
 fi

--- a/create_db.sh
+++ b/create_db.sh
@@ -9,7 +9,7 @@ db=${DB_PATH:-"metadata-db"}
 export PGPASSWORD=${PGPASSWORD:-`cat /run/secrets/metadata-db-secret`}
 export PGUSER=${PGUSER:-`cat /run/secrets/metadata-db-user`}
 
-until pg_isready -h metadata-db -p 5432 -U $PGUSER; do
+until pg_isready -h "$db" -p 5432 -U $PGUSER; do
   echo "Waiting for the database to be ready..."
   sleep 1
 done

--- a/create_db.sh
+++ b/create_db.sh
@@ -22,7 +22,7 @@ psql --quiet -h "$db" -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1
 if [[ $? -ne 0 ]]; then
     echo "initializing database..."
     createdb -h "$db" -U $PGUSER genomic
-    psql --quiet -h "$db" -U $PGUSER -a -d genomic -f data/files.sql
+    psql --quiet -h "$db" -U $PGUSER -a -d genomic -f data/files.sql >>setup_out.txt
     echo "...done"
 fi
 
@@ -33,7 +33,7 @@ if [[ $numgenes -lt 5 ]]; then
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
 
-    psql --quiet -h "$db" -U $PGUSER -d genomic -a -f genes.sql
+    psql --quiet -h "$db" -U $PGUSER -d genomic -a -f genes.sql >>setup_out.txt
     # rm genes.sql
     echo "...done"
 fi

--- a/data/files.sql
+++ b/data/files.sql
@@ -1,4 +1,3 @@
-PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 CREATE TABLE drs_object (
         id VARCHAR NOT NULL,
@@ -194,7 +193,7 @@ CREATE TABLE sample (
 -- transcript_name	NR_046018.2	Transcript name from NCBI RefSeq
 -- contig	1	Reference sequence chromosome or scaffold
 -- start	11873	Transcription start position (or end position for minus strand item)
--- end	14409	Transcription end position (or start position for minus strand item)
+-- endpos	14409	Transcription end position (or start position for minus strand item)
 
 CREATE TABLE ncbiRefSeq (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -203,60 +202,60 @@ CREATE TABLE ncbiRefSeq (
 	transcript_name varchar(255) NOT NULL,
 	contig varchar(10) NOT NULL,
 	start int(10) NOT NULL,
-	end int(10) NOT NULL,
+	endpos int(10) NOT NULL,
 	UNIQUE(reference_genome, contig, gene_name, transcript_name)
 );
 
 -- insert reference sequences for chromosomes: ncbi reference name is in transcript name, but gene name is empty
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000001.11", "1", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000002.12", "2", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000003.12", "3", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000004.12", "4", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000005.10", "5", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000006.12", "6", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000007.14", "7", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000008.11", "8", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000009.12", "9", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000010.11", "10", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000011.10", "11", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000012.12", "12", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000013.11", "13", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000014.9", "14", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000015.10", "15", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000016.10", "16", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000017.11", "17", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000018.10", "18", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000019.10", "19", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000020.11", "20", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000021.9", "21", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000022.11", "22", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000023.11", "X", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_000024.10", "Y", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg38", "NC_012920.1", "MT", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000001.10", "1", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000002.11", "2", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000003.11", "3", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000004.11", "4", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000005.9", "5", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000006.11", "6", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000007.13", "7", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000008.10", "8", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000009.11", "9", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000010.10", "10", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000011.9", "11", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000012.11", "12", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000013.10", "13", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000014.8", "14", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000015.9", "15", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000016.9", "16", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000017.10", "17", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000018.9", "18", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000019.9", "19", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000020.10", "20", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000021.8", "21", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000022.10", "22", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000023.10", "X", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_000024.9", "Y", 0, 0, "");
-INSERT OR IGNORE INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, end, gene_name) VALUES ("hg37", "NC_012920.1", "MT", 0, 0, "");
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000001.11", "1", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000002.12", "2", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000003.12", "3", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000004.12", "4", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000005.10", "5", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000006.12", "6", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000007.14", "7", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000008.11", "8", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000009.12", "9", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000010.11", "10", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000011.10", "11", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000012.12", "12", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000013.11", "13", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000014.9", "14", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000015.10", "15", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000016.10", "16", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000017.11", "17", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000018.10", "18", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000019.10", "19", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000020.11", "20", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000021.9", "21", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000022.11", "22", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000023.11", "X", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000024.10", "Y", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_012920.1", "MT", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000001.10", "1", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000002.11", "2", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000003.11", "3", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000004.11", "4", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000005.9", "5", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000006.11", "6", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000007.13", "7", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000008.10", "8", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000009.11", "9", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000010.10", "10", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000011.9", "11", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000012.11", "12", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000013.10", "13", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000014.8", "14", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000015.9", "15", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000016.9", "16", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000017.10", "17", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000018.9", "18", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000019.9", "19", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000020.10", "20", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000021.8", "21", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000022.10", "22", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000023.10", "X", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000024.9", "Y", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_012920.1", "MT", 0, 0, "") ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/data/files.sql
+++ b/data/files.sql
@@ -14,24 +14,22 @@ CREATE TABLE drs_object (
         PRIMARY KEY (id)
 );
 CREATE TABLE access_method (
-        id INTEGER NOT NULL,
-        drs_object_id INTEGER,
+        id SERIAL PRIMARY KEY,
+        drs_object_id VARCHAR,
         type VARCHAR,
         access_id VARCHAR,
         region VARCHAR,
         url VARCHAR,
         headers VARCHAR,
-        PRIMARY KEY (id),
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
 CREATE TABLE content_object (
-        id INTEGER NOT NULL,
-        drs_object_id INTEGER,
+        id SERIAL PRIMARY KEY,
+        drs_object_id VARCHAR,
         name VARCHAR,
         contents_id VARCHAR,
         drs_uri VARCHAR,
         contents VARCHAR,
-        PRIMARY KEY (id),
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
 CREATE TABLE dataset (
@@ -147,13 +145,13 @@ CREATE TABLE variantfile (
 	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
 CREATE TABLE pos_bucket (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id SERIAL PRIMARY KEY,
 	pos_bucket_id INTEGER NOT NULL,
 	contig_id VARCHAR,
 	FOREIGN KEY(contig_id) REFERENCES contig (id)
 );
 CREATE TABLE header (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id SERIAL PRIMARY KEY,
 	text VARCHAR NOT NULL
 );
 CREATE TABLE contig_variantfile_association (
@@ -179,7 +177,7 @@ CREATE TABLE pos_bucket_variantfile_association (
 	FOREIGN KEY(variantfile_id) REFERENCES variantfile (id)
 );
 CREATE TABLE sample (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id SERIAL PRIMARY KEY,
 	sample_id VARCHAR,
 	variantfile_id VARCHAR,
 	FOREIGN KEY(variantfile_id) REFERENCES variantfile (id)
@@ -196,66 +194,66 @@ CREATE TABLE sample (
 -- endpos	14409	Transcription end position (or start position for minus strand item)
 
 CREATE TABLE ncbiRefSeq (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	id SERIAL PRIMARY KEY,
 	reference_genome varchar(10) NOT NULL,
 	gene_name varchar(255) NOT NULL,
 	transcript_name varchar(255) NOT NULL,
-	contig varchar(10) NOT NULL,
-	start int(10) NOT NULL,
-	endpos int(10) NOT NULL,
+	contig varchar(25) NOT NULL,
+	start int NOT NULL,
+	endpos int NOT NULL,
 	UNIQUE(reference_genome, contig, gene_name, transcript_name)
 );
 
 -- insert reference sequences for chromosomes: ncbi reference name is in transcript name, but gene name is empty
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000001.11", "1", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000002.12", "2", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000003.12", "3", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000004.12", "4", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000005.10", "5", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000006.12", "6", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000007.14", "7", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000008.11", "8", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000009.12", "9", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000010.11", "10", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000011.10", "11", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000012.12", "12", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000013.11", "13", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000014.9", "14", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000015.10", "15", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000016.10", "16", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000017.11", "17", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000018.10", "18", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000019.10", "19", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000020.11", "20", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000021.9", "21", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000022.11", "22", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000023.11", "X", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_000024.10", "Y", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg38", "NC_012920.1", "MT", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000001.10", "1", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000002.11", "2", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000003.11", "3", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000004.11", "4", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000005.9", "5", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000006.11", "6", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000007.13", "7", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000008.10", "8", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000009.11", "9", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000010.10", "10", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000011.9", "11", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000012.11", "12", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000013.10", "13", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000014.8", "14", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000015.9", "15", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000016.9", "16", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000017.10", "17", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000018.9", "18", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000019.9", "19", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000020.10", "20", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000021.8", "21", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000022.10", "22", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000023.10", "X", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_000024.9", "Y", 0, 0, "") ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ("hg37", "NC_012920.1", "MT", 0, 0, "") ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000001.11', '1', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000002.12', '2', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000003.12', '3', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000004.12', '4', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000005.10', '5', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000006.12', '6', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000007.14', '7', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000008.11', '8', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000009.12', '9', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000010.11', '10', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000011.10', '11', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000012.12', '12', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000013.11', '13', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000014.9', '14', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000015.10', '15', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000016.10', '16', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000017.11', '17', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000018.10', '18', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000019.10', '19', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000020.11', '20', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000021.9', '21', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000022.11', '22', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000023.11', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000024.10', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000001.10', '1', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000002.11', '2', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000003.11', '3', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000004.11', '4', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000005.9', '5', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000006.11', '6', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000007.13', '7', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000008.10', '8', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000009.11', '9', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000010.10', '10', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000011.9', '11', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000012.11', '12', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000013.10', '13', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000014.8', '14', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000015.9', '15', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000016.9', '16', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000017.10', '17', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000018.9', '18', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000019.9', '19', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000020.10', '20', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000021.8', '21', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000022.10', '22', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000023.10', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000024.9', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/data/refseq/README.txt
+++ b/data/refseq/README.txt
@@ -8,6 +8,6 @@ s/^(.+?)\t(.+?)\t(.+?)\t(.)\t(\d+)\t(\d+)\t(\d+)\t(\d+)\t(\d+)\t(.+?)\t(.+?)\t.\
 now the columns left are:
 name, contig, txStart, txEnd, name2
 which correspond to our:
-transcript_name, contig, start, end, gene_name
+transcript_name, contig, start, endpos, gene_name
 
 These files are saved as ncbiRefSeqSelect.hg37.txt and ncbiRefSeqSelect.hg38.txt.

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -201,9 +201,10 @@ def search(raw_req):
             for gene in genes:
                 if gene['reference_genome'] == actual_params['reference_genome']:
                     actual_params['reference_name'] = database.normalize_contig(gene['contig'])
-                    actual_params['start'] = gene['start']
-                    actual_params['end'] = gene['end']
-                    break
+                    if actual_params['reference_name'] is not None:
+                        actual_params['start'] = gene['start']
+                        actual_params['end'] = gene['end']
+                        break
         else:
             response = {
                     'error': {

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -18,7 +18,7 @@ else:
     raise Exception("Could not determine how to get PostGres password")
 
 DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
-DB_PATH = re.sub("HOST", "DB_PATH", DB_PATH)
+DB_PATH = re.sub("HOST", os.environ.get("DB_PATH"), DB_PATH)
 print(f"Password is: {password}")
 
 CHUNK_SIZE = int(config['DEFAULT']['ChunkSize'])

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -18,6 +18,7 @@ else:
     raise Exception("Could not determine how to get PostGres password")
 
 DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
+DB_PATH = re.sub("HOST", "DB_PATH", DB_PATH)
 print(f"Password is: {password}")
 
 CHUNK_SIZE = int(config['DEFAULT']['ChunkSize'])

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -1,5 +1,6 @@
 import configparser
 import os
+import re
 from minio import Minio
 
 config = configparser.ConfigParser(interpolation=None)
@@ -8,9 +9,14 @@ config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../c
 AUTHZ = config['authz']
 HTSGET_URL = os.getenv("HTSGET_URL", f"http://localhost:{config['DEFAULT']['Port']}")
 
-DB_PATH = config['paths']['DBPath']
-if os.environ.get("DB_PATH") is not None:
-    DB_PATH = f"sqlite:///{os.environ.get('DB_PATH')}"
+# DB_PATH = config['paths']['DBPath']
+# if os.environ.get("DB_PATH") is not None:
+#     DB_PATH = f"sqlite:///{os.environ.get('DB_PATH')}"
+
+with open(os.environ.get("POSTGRES_PASSWORD_FILE"), 'r') as file:
+    password = file.read()
+    DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
+print(f"Password is: {password}")
 
 CHUNK_SIZE = int(config['DEFAULT']['ChunkSize'])
 

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -9,13 +9,15 @@ config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../c
 AUTHZ = config['authz']
 HTSGET_URL = os.getenv("HTSGET_URL", f"http://localhost:{config['DEFAULT']['Port']}")
 
-# DB_PATH = config['paths']['DBPath']
-# if os.environ.get("DB_PATH") is not None:
-#     DB_PATH = f"sqlite:///{os.environ.get('DB_PATH')}"
+if os.environ.get("PGPASSWORD") is not None:
+    password = os.environ.get("PGPASSWORD")
+elif os.environ.get("POSTGRES_PASSWORD_FILE") is not None and os.path.exists(os.environ.get("POSTGRES_PASSWORD_FILE")):
+    with open(os.environ.get("POSTGRES_PASSWORD_FILE"), 'r') as file:
+        password = file.read()
+else:
+    raise Exception("Could not determine how to get PostGres password")
 
-with open(os.environ.get("POSTGRES_PASSWORD_FILE"), 'r') as file:
-    password = file.read()
-    DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
+DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
 print(f"Password is: {password}")
 
 CHUNK_SIZE = int(config['DEFAULT']['ChunkSize'])

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -512,10 +512,13 @@ def create_dataset(obj):
 
 def delete_dataset(dataset_id):
     with Session() as session:
-        new_object = session.query(Dataset).filter_by(id=dataset_id).one()
-        session.delete(new_object)
+        dataset_objs = session.query(Dataset).filter_by(id=dataset_id).all()
+        for dataset_obj in dataset_objs:
+            for drs_obj in dataset_obj.associated_drs:
+                session.delete(drs_obj)
+            session.delete(dataset_obj)
         session.commit()
-        return json.loads(str(new_object))
+        return json.loads(str(dataset_objs))
 
 
 def list_refseqs(reference_genome="hg38"):

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from config import DB_PATH, BUCKET_SIZE, HTSGET_URL
 
 
-engine = create_engine(DB_PATH, echo=False)
+engine = create_engine(DB_PATH, echo=True)
 
 ObjectDBBase = declarative_base()
 
@@ -218,7 +218,7 @@ class Header(ObjectDBBase):
 ## gene search entities
 
 class NCBIRefSeq(ObjectDBBase):
-    __tablename__ = 'ncbiRefSeq'
+    __tablename__ = 'ncbirefseq'
     id = Column(Integer, primary_key=True)
     reference_genome = Column(String)
     gene_name = Column(String)

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -225,7 +225,7 @@ class NCBIRefSeq(ObjectDBBase):
     transcript_name = Column(String)
     contig = Column(String)
     start = Column(Integer)
-    end = Column(Integer)
+    endpos = Column(Integer)
 
     def __repr__(self):
         result = {
@@ -235,7 +235,7 @@ class NCBIRefSeq(ObjectDBBase):
             'transcript_name': self.transcript_name,
             'contig': self.contig,
             'start': self.start,
-            'end': self.end
+            'end': self.endpos
         }
         return json.dumps(result)
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from config import DB_PATH, BUCKET_SIZE, HTSGET_URL
 
 
-engine = create_engine(DB_PATH, echo=True)
+engine = create_engine(DB_PATH, echo=False)
 
 ObjectDBBase = declarative_base()
 

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -168,7 +168,7 @@ paths:
     delete:
       summary: Delete a dataset.
       description: >-
-        Returns object metadata, and a list of access methods that can be used to fetch object bytes.
+        Delete a dataset, and all associated DRS objects.
       operationId: drs_operations.delete_dataset
       responses:
           200:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v1.0.0
 pytest==7.2.0
 uwsgi==2.0.21
 connexion[swagger-ui]
+psycopg2-binary

--- a/tests/snippets/models.py
+++ b/tests/snippets/models.py
@@ -1,4 +1,4 @@
-import sqlite3
+# import sqlite3
 import os.path
 
 # conn = sqlite3.connect('files.db')

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -58,7 +58,7 @@ def test_post_objects(drs_objects):
     for obj in drs_objects:
         url = f"{HOST}/ga4gh/drs/v1/objects"
         response = requests.request("POST", url, json=obj, headers=headers)
-        print(f"POST {obj['name']}: {response.text}")
+        print(f"POST {obj}: {response.text}")
         assert response.status_code == 200
 
 
@@ -466,6 +466,7 @@ def test_beacon_search_annotations():
     }
     response = requests.post(url, json=body, headers=get_headers())
     found_gene = False
+    print(response.json())
     for var in response.json()['response']:
         if 'molecularAttributes' in var:
             if 'geneIds' in var['molecularAttributes']:


### PR DESCRIPTION
# Jira tickets
[DIG-1308](https://candig.atlassian.net/browse/DIG-1308)
[DIG-1309](https://candig.atlassian.net/browse/DIG-1309)

# Description
This PR switches HTSGet from using a sqlite backend to Postgres, This also renames the `ncbiRefSeq` table to `ncbirefseq`, as the backend requires it, and its value of `end` to `endpos` (internally only), as `end` is a keyword in Postgres.

# Related
This requires a change to CanDIGv2 as well, in [this PR](https://github.com/CanDIG/CanDIGv2/pull/296)

# To test:
- Should just run integration-tests I think.

[DIG-1308]: https://candig.atlassian.net/browse/DIG-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIG-1309]: https://candig.atlassian.net/browse/DIG-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ