### PR TITLE
DIG-1235, 1237: htsget returns completeness stats

### DIFF
--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -271,6 +271,7 @@ components:
       required:
         - id
         - contents
+        - description
 #        - self_uri
 #        - size
 #        - created_time
@@ -337,7 +338,8 @@ components:
             $ref: '#/components/schemas/GenomicContentsObject'
         description:
           type: string
-          description: A human readable description of the `DrsObject`.
+          enum:
+            - sample
         aliases:
           type: array
           items:
@@ -353,6 +355,7 @@ components:
       required:
         - id
         - contents
+        - description
 #        - self_uri
 #        - size
 #        - created_time
@@ -427,7 +430,10 @@ components:
               - $ref: '#/components/schemas/SampleContentsObject'
         description:
           type: string
-          description: A human readable description of the `DrsObject`.
+          description: type of sequencing data
+          enum:
+            - wgs
+            - wts
         aliases:
           type: array
           items:
@@ -443,6 +449,7 @@ components:
       required:
         - id
         - access_methods
+        - description
 #        - self_uri
 #        - size
 #        - created_time
@@ -515,7 +522,9 @@ components:
             The list of access methods that can be used to fetch the `DrsObject`.
         description:
           type: string
-          description: A description of this genomic data file
+          enum:
+            - variant
+            - read
         mime_type:
           type: string
           description: A string providing the mime-type of the DrsObject.
@@ -534,6 +543,7 @@ components:
       required:
         - id
         - access_methods
+        - description
 #        - self_uri
 #        - size
 #        - created_time
@@ -605,7 +615,8 @@ components:
             The list of access methods that can be used to fetch the `DrsObject`.
         description:
           type: string
-          description: A description of this genomic data file
+          enum:
+            - index
         mime_type:
           type: string
           description: A string providing the mime-type of the DrsObject.
@@ -691,6 +702,7 @@ components:
           description: The identifier of the genomic object
         id:
           type: string
+          description: The identifier of the genomic object
         drs_uri:
           type: array
           description: The DRS uri(s) to the GenomicDrsObject

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -691,8 +691,6 @@ components:
           description: The identifier of the genomic object
         id:
           type: string
-          enum:
-            - genomic
         drs_uri:
           type: array
           description: The DRS uri(s) to the GenomicDrsObject

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -319,6 +319,40 @@ paths:
                                 type: object
                                 $ref: '#/components/schemas/GeneSearchResultsTicket'
 
+    /samples/{id}:
+        get:
+            summary: Get metadata about a sample
+            operationId: htsget_operations.get_sample
+            description: Get MoH-relevant genomic information about a sample
+            parameters:
+                - $ref: '#/components/parameters/authHeaderParam'
+                - $ref: "#/components/parameters/idPathParam"
+            responses:
+                200:
+                    description: Success
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SampleTicket'
+    /samples:
+        post:
+            summary: Get metadata about multiple samples
+            operationId: htsget_operations.get_samples
+            description: Get MoH-relevant genomic information about a list of samples
+            parameters:
+                - $ref: '#/components/parameters/authHeaderParam'
+            requestBody:
+                $ref: '#/components/requestBodies/SamplesRequestBody'
+            responses:
+                200:
+                    description: Success
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/SampleTicket'
+
 tags:
     - name: Reads
       description: |
@@ -744,6 +778,22 @@ components:
                                                 - hg38
                                         region:
                                             $ref: '#/components/schemas/Region'
+        SampleTicket:
+            type: object
+            properties:
+                sample_id:
+                    type: string
+                    description: MoH submitter_sample_id from a Sample Registration associated with a specimen.
+                genome:
+                    type: array
+                    description: An array of associated GenomicDrsObjects that describe reads, e.g. bams.
+                    items:
+                        type: string
+                transcriptome:
+                    type: array
+                    description: An array of associated GenomicDrsObjects that describe transcriptome data.
+                    items:
+                        type: string
 
         # ERROR SCHEMAS
         Error:
@@ -817,6 +867,14 @@ components:
             required: false
             schema:
                 type: string
+        sampleIdPathParam:
+            in: path
+            name: id
+            description: MoH Sample Registration ID for a sample with associated genomic data
+            required: true
+            schema:
+                type: string
+                format: path
         readsFormatParam:
             in: query
             name: format
@@ -943,6 +1001,20 @@ components:
                 application/json:
                     schema:
                         $ref: '#/components/schemas/ReadsRequestBody'
+        SamplesRequestBody:
+            description: List of samples requested
+            required: false
+            content:
+                application/json:
+                    schema:
+                        type: object
+                        properties:
+                            samples:
+                                type: array
+                                items:
+                                    type: string
+
+
     responses:
         400BadRequestError:
             description: The request was not processed, as the request parameters did not adhere to the specification

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -228,7 +228,7 @@ def get_sample(id_=None):
     # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
     # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
     sample_drs_obj, result_code = drs_operations.get_object(id_)
-    if result_code == 200 and "contents" in sample_drs_obj:
+    if result_code == 200 and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
         for contents_obj in sample_drs_obj["contents"]:
             drs_obj = database.get_drs_object(contents_obj["id"])
             if drs_obj is not None:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -217,6 +217,39 @@ def get_matching_transcripts(id_=None):
     return get_matching_genes(id_=id_, type="transcript_name")
 
 
+@app.route('/samples/<path:id_>')
+def get_sample(id_=None):
+    result = {
+        "sample_id": id_,
+        "genomes": [],
+        "transcriptomes": []
+    }
+
+    # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
+    # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
+    sample_drs_obj, result_code = drs_operations.get_object(id_)
+    if result_code == 200 and "contents" in sample_drs_obj:
+        for contents_obj in sample_drs_obj["contents"]:
+            drs_obj = database.get_drs_object(contents_obj["id"])
+            if drs_obj is not None:
+                if drs_obj["description"] == "wgs":
+                    result["genomes"].append(drs_obj["id"])
+                elif drs_obj["description"] == "wts":
+                    result["transcriptomes"].append(drs_obj["id"])
+        return result, 200
+    return {"message": f"Could not find sample {id_}"}, 404
+
+
+def get_samples():
+    req = connexion.request.json
+    result = []
+    for sample in req["samples"]:
+        res, status_code = get_sample(sample)
+        if status_code == 200:
+            result.append(res)
+    return result, 200
+
+
 def _get_htsget_url(id, reference_name, slice_start, slice_end, file_type, data=True):
     """
     Creates single slice for a region in a file. Returns an HTSGetURL object.

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -271,6 +271,21 @@ def test_add_sample_drs(input, program_id):
     assert len(genomic_drs_obj["contents"]) == contents_count + 1
 
 
+@pytest.mark.parametrize('input, program_id', get_ingest_file())
+def test_sample_stats(input, program_id):
+    headers = get_headers()
+
+    sample = get_ingest_sample_names(input['genomic_id'])
+    print(sample)
+    # look for the sample
+    get_url = f"{HOST}/htsget/v1/samples/{sample[list(sample.keys()).pop()]}"
+    response = requests.request("GET", get_url, headers=headers)
+    if response.status_code == 200:
+        assert response.status_code == 200
+
+    assert input['genomic_id'] in response.json()['genomes']
+
+
 def invalid_start_end_data():
     return [(17123456, 23588), (9203, 42220938)]
 

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -188,18 +188,14 @@ def get_ingest_file():
     return [
         (
             {
-                "genomic_id": "multisample_1",
+                "genomic_id": "NA18537",
                 "samples": [
                     {
-                        "sample_registration_id": "SAMPLE_REGISTRATION_3",
-                        "sample_name_in_file": "TUMOR"
-                    },
-                    {
-                        "sample_registration_id": "SAMPLE_REGISTRATION_4",
-                        "sample_name_in_file": "NORMAL"
+                        "sample_registration_id": "NA18537-wgs",
+                        "sample_name_in_file": "NA18537"
                     }
                 ]
-            }, "SYNTHETIC-2"
+            }, "1000Genomes"
         )
     ]
 
@@ -225,6 +221,7 @@ def test_add_sample_drs(input, program_id):
     if response.status_code == 200:
         assert response.status_code == 200
     genomic_drs_obj = response.json()
+    contents_count = len(genomic_drs_obj["contents"])
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
     for sample in input['samples']:
@@ -271,7 +268,7 @@ def test_add_sample_drs(input, program_id):
     response = requests.request("GET", get_url, headers=headers)
     if response.status_code == 200:
         assert response.status_code == 200
-    assert len(genomic_drs_obj["contents"]) == 4
+    assert len(genomic_drs_obj["contents"]) == contents_count + 1
 
 
 def invalid_start_end_data():

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -443,14 +443,6 @@ def test_beacon_post_search(body, count, cases):
     assert len(response.json()['response']) == count
     assert len(response.json()['response'][0]['caseLevelData']) == cases
 
-    # check to see if the sample names got in:
-    samples = get_ingest_sample_names('multisample_1')
-    for cld in response.json()['response'][0]['caseLevelData']:
-        if cld['analysisId'] == 'multisample_1':
-            assert cld['biosampleId'] in samples.values()
-        else:
-            assert cld['biosampleId'] not in samples.values()
-
 
 # if we search for NBPF1, we should find records in test.vcf that contain NBPF1 in their VEP annotations.
 def test_beacon_search_annotations():

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -121,7 +121,7 @@ def test_install_public_object():
         {
             "aliases": [],
             "checksums": [],
-            "description": "",
+            "description": "index",
             "id": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi",
             "mime_type": "application/octet-stream",
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi",
@@ -137,7 +137,7 @@ def test_install_public_object():
         {
             "aliases": [],
             "checksums": [],
-            "description": "",
+            "description": "variant",
             "id": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
             "mime_type": "application/octet-stream",
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
@@ -169,7 +169,7 @@ def test_install_public_object():
                 "id": "index"
               }
             ],
-            "description": "",
+            "description": "wgs",
             "id": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes",
             "mime_type": "application/octet-stream",
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes",
@@ -240,6 +240,7 @@ def test_add_sample_drs(input, program_id):
         # create a sampledrsobject to correspond to each sample:
         sample_drs_object = {
             "id": sample_id,
+            "description": "sample",
             "contents": [
                 {
                     "drs_uri": [
@@ -509,6 +510,7 @@ def drs_objects():
         # make a genomicdrsobj:
         genomic_drs_obj = {
             "id": drs_obj,
+            "description": "wgs",
             "mime_type": "application/octet-stream",
             "name": drs_obj,
             "contents": [],
@@ -520,6 +522,7 @@ def drs_objects():
         index_file = drs_objects[drs_obj].pop("index")
         result.append({
             "id": index_file,
+            "description": "index",
             "mime_type": "application/octet-stream",
             "name": index_file,
             "version": "v1"
@@ -538,6 +541,7 @@ def drs_objects():
         data_file = drs_objects[drs_obj].pop(type)
         result.append({
             "id": data_file,
+            "description": type,
             "mime_type": "application/octet-stream",
             "name": data_file,
             "version": "v1"


### PR DESCRIPTION
There are new endpoints:

`http://candig.docker.internal:5080/genomics/htsget/v1/samples/1000Genomes~NA18537-wgs` with an admin bearer token should return:
```
{
  "genomes": [
    "NA18537"
  ],
  "sample_id": "1000Genomes~NA18537-wgs",
  "transcriptomes": []
}
```

This is tested in pytest.