### PR TITLE
DIG-1329, DIG-1330: Dataset to cohort refactoring

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -18,7 +18,7 @@ echo "database is at $db"
 pwd
 
 # initialize the db if it's not already there:
-psql --quiet -h "$db" -U $PGUSER -d genomic -c "SELECT * from ncbiRefSeq limit 1"
+psql --quiet -h "$db" -U $PGUSER -d genomic -c "SELECT * from ncbirefseq limit 1"
 if [[ $? -ne 0 ]]; then
     echo "initializing database..."
     createdb -h "$db" -U $PGUSER genomic

--- a/data/files.sql
+++ b/data/files.sql
@@ -1,4 +1,8 @@
 BEGIN TRANSACTION;
+CREATE TABLE cohort (
+	id VARCHAR NOT NULL,
+	PRIMARY KEY (id)
+);
 CREATE TABLE drs_object (
         id VARCHAR NOT NULL,
         name VARCHAR,
@@ -11,7 +15,9 @@ CREATE TABLE drs_object (
         checksums VARCHAR,
         description VARCHAR,
         aliases VARCHAR,
-        PRIMARY KEY (id)
+        cohort_id VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(cohort_id) REFERENCES cohort (id)
 );
 CREATE TABLE access_method (
         id SERIAL PRIMARY KEY,
@@ -31,11 +37,6 @@ CREATE TABLE content_object (
         drs_uri VARCHAR,
         contents VARCHAR,
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
-);
-CREATE TABLE cohort (
-	id VARCHAR NOT NULL,
-	PRIMARY KEY (id),
-	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
 CREATE TABLE contig (
 	id VARCHAR NOT NULL,

--- a/data/files.sql
+++ b/data/files.sql
@@ -177,7 +177,7 @@ CREATE TABLE sample (
 	FOREIGN KEY(variantfile_id) REFERENCES variantfile (id)
 );
 
--- ncbiRefSeq table modified from https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/
+-- ncbirefseq table modified from https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/
 
 -- field	example	description
 -- reference_genome	hg38	Reference genome build
@@ -187,7 +187,7 @@ CREATE TABLE sample (
 -- start	11873	Transcription start position (or end position for minus strand item)
 -- endpos	14409	Transcription end position (or start position for minus strand item)
 
-CREATE TABLE ncbiRefSeq (
+CREATE TABLE ncbirefseq (
 	id SERIAL PRIMARY KEY,
 	reference_genome varchar(10) NOT NULL,
 	gene_name varchar(255) NOT NULL,
@@ -199,55 +199,55 @@ CREATE TABLE ncbiRefSeq (
 );
 
 -- insert reference sequences for chromosomes: ncbi reference name is in transcript name, but gene name is empty
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000001.11', '1', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000002.12', '2', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000003.12', '3', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000004.12', '4', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000005.10', '5', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000006.12', '6', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000007.14', '7', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000008.11', '8', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000009.12', '9', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000010.11', '10', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000011.10', '11', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000012.12', '12', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000013.11', '13', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000014.9', '14', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000015.10', '15', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000016.10', '16', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000017.11', '17', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000018.10', '18', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000019.10', '19', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000020.11', '20', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000021.9', '21', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000022.11', '22', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000023.11', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000024.10', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000001.10', '1', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000002.11', '2', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000003.11', '3', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000004.11', '4', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000005.9', '5', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000006.11', '6', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000007.13', '7', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000008.10', '8', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000009.11', '9', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000010.10', '10', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000011.9', '11', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000012.11', '12', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000013.10', '13', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000014.8', '14', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000015.9', '15', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000016.9', '16', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000017.10', '17', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000018.9', '18', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000019.9', '19', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000020.10', '20', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000021.8', '21', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000022.10', '22', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000023.10', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000024.9', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
-INSERT INTO ncbiRefSeq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000001.11', '1', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000002.12', '2', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000003.12', '3', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000004.12', '4', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000005.10', '5', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000006.12', '6', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000007.14', '7', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000008.11', '8', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000009.12', '9', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000010.11', '10', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000011.10', '11', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000012.12', '12', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000013.11', '13', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000014.9', '14', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000015.10', '15', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000016.10', '16', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000017.11', '17', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000018.10', '18', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000019.10', '19', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000020.11', '20', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000021.9', '21', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000022.11', '22', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000023.11', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_000024.10', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg38', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000001.10', '1', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000002.11', '2', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000003.11', '3', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000004.11', '4', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000005.9', '5', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000006.11', '6', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000007.13', '7', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000008.10', '8', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000009.11', '9', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000010.10', '10', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000011.9', '11', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000012.11', '12', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000013.10', '13', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000014.8', '14', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000015.9', '15', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000016.9', '16', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000017.10', '17', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000018.9', '18', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000019.9', '19', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000020.10', '20', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000021.8', '21', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000022.10', '22', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000023.10', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000024.9', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
+INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/data/files.sql
+++ b/data/files.sql
@@ -37,13 +37,6 @@ CREATE TABLE cohort (
 	PRIMARY KEY (id),
 	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-CREATE TABLE cohort_association (
-	cohort_id VARCHAR NOT NULL,
-	drs_object_id VARCHAR NOT NULL,
-	PRIMARY KEY (cohort_id, drs_object_id),
-	FOREIGN KEY(cohort_id) REFERENCES cohort (id),
-	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
-);
 CREATE TABLE contig (
 	id VARCHAR NOT NULL,
 	PRIMARY KEY (id)

--- a/data/files.sql
+++ b/data/files.sql
@@ -32,15 +32,16 @@ CREATE TABLE content_object (
         contents VARCHAR,
         FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-CREATE TABLE dataset (
+CREATE TABLE cohort (
 	id VARCHAR NOT NULL,
-	PRIMARY KEY (id)
+	PRIMARY KEY (id),
+	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
-CREATE TABLE dataset_association (
-	dataset_id VARCHAR NOT NULL,
+CREATE TABLE cohort_association (
+	cohort_id VARCHAR NOT NULL,
 	drs_object_id VARCHAR NOT NULL,
-	PRIMARY KEY (dataset_id, drs_object_id),
-	FOREIGN KEY(dataset_id) REFERENCES dataset (id),
+	PRIMARY KEY (cohort_id, drs_object_id),
+	FOREIGN KEY(cohort_id) REFERENCES cohort (id),
 	FOREIGN KEY(drs_object_id) REFERENCES drs_object (id)
 );
 CREATE TABLE contig (

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -18,11 +18,11 @@ def is_authed(id_, request):
     if is_site_admin(request):
         return 200
     if "Authorization" in request.headers:
-        authed_datasets = get_authorized_datasets(request)
+        authed_cohorts = get_authorized_cohorts(request)
         obj = database.get_drs_object(id_)
-        if obj is not None and 'datasets' in obj:
-            for dataset in obj["datasets"]:
-                if dataset in authed_datasets:
+        if obj is not None and 'cohorts' in obj:
+            for cohort in obj["cohorts"]:
+                if cohort in authed_cohorts:
                     return 200
     else:
         return 401
@@ -36,12 +36,12 @@ def is_testing(request):
         return True
 
 
-def get_authorized_datasets(request):
+def get_authorized_cohorts(request):
     try:
         return authx.auth.get_opa_datasets(request, opa_url=AUTHZ['CANDIG_OPA_URL'], admin_secret=AUTHZ['CANDIG_OPA_SECRET'])
     except Exception as e:
-        print(f"Couldn't authorize datasets: {type(e)} {str(e)}")
-        app.logger.warning(f"Couldn't authorize datasets: {type(e)} {str(e)}")
+        print(f"Couldn't authorize cohorts: {type(e)} {str(e)}")
+        app.logger.warning(f"Couldn't authorize cohorts: {type(e)} {str(e)}")
         return []
 
 

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -20,10 +20,9 @@ def is_authed(id_, request):
     if "Authorization" in request.headers:
         authed_cohorts = get_authorized_cohorts(request)
         obj = database.get_drs_object(id_)
-        if obj is not None and 'cohorts' in obj:
-            for cohort in obj["cohorts"]:
-                if cohort in authed_cohorts:
-                    return 200
+        if obj is not None and 'cohort' in obj:
+            if obj['cohort'] in authed_cohorts:
+                return 200
     else:
         return 401
     return 403

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -566,7 +566,7 @@ components:
           type: boolean
         id:
           description: id of the resultset
-          example: datasetA
+          example: cohortA
           type: string
         info:
           description: Additional details that could be of interest about the Resultset. Provided to clearly enclose any attribute that is not part of the Beacon specification.

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -274,7 +274,7 @@ def search(raw_req):
             response['responseSummary']['numTotalResults'] = len(resultset)
             response['responseSummary']['exists'] = True
 
-        # if the request granularity was "record", check to see that the user is actually authorized to see any datasets:
+        # if the request granularity was "record", check to see that the user is actually authorized to see any cohorts:
         response['beaconHandovers'] = []
         for drs_obj in variants_by_file.keys():
             handover, status_code = htsget_operations.get_variants(id_=drs_obj, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -364,9 +364,12 @@ def get_drs_object(object_id, expand=False):
         return None
 
 
-def list_drs_objects():
+def list_drs_objects(cohort_id=None):
     with Session() as session:
-        result = session.query(DrsObject).all()
+        if cohort_id is not None:
+            result = session.query(DrsObject).filter_by(cohort_id=cohort_id).all()
+        else:
+            result = session.query(DrsObject).all()
         if result is not None:
             new_obj = json.loads(str(result))
             return new_obj

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -30,6 +30,8 @@ paths:
       - $ref: '#/components/parameters/BearerAuth'
     get:
       summary: List all DRS objects
+      parameters:
+      - $ref: '#/components/parameters/CohortIdQuery'
       description: >-
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
       operationId: drs_operations.list_objects
@@ -192,6 +194,12 @@ components:
       description: CohortId
       schema:
         type: string
+    CohortIdQuery:
+        in: query
+        name: cohort_id
+        description: CohortId
+        schema:
+          type: string
     ObjectId:
       in: path
       name: object_id

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -272,6 +272,7 @@ components:
         - id
         - contents
         - description
+        - cohort
 #        - self_uri
 #        - size
 #        - created_time
@@ -340,6 +341,9 @@ components:
           type: string
           enum:
             - sample
+        cohort:
+          type: string
+          description: The cohort this object was ingested as part of
         aliases:
           type: array
           items:
@@ -356,6 +360,7 @@ components:
         - id
         - contents
         - description
+        - cohort
 #        - self_uri
 #        - size
 #        - created_time
@@ -434,6 +439,9 @@ components:
           enum:
             - wgs
             - wts
+        cohort:
+            type: string
+            description: The cohort this object was ingested as part of
         aliases:
           type: array
           items:
@@ -450,6 +458,7 @@ components:
         - id
         - access_methods
         - description
+        - cohort
 #        - self_uri
 #        - size
 #        - created_time
@@ -525,6 +534,9 @@ components:
           enum:
             - variant
             - read
+        cohort:
+            type: string
+            description: The cohort this object was ingested as part of
         mime_type:
           type: string
           description: A string providing the mime-type of the DrsObject.
@@ -544,6 +556,7 @@ components:
         - id
         - access_methods
         - description
+        - cohort
 #        - self_uri
 #        - size
 #        - created_time
@@ -617,6 +630,9 @@ components:
           type: string
           enum:
             - index
+        cohort:
+            type: string
+            description: The cohort this object was ingested as part of
         mime_type:
           type: string
           description: A string providing the mime-type of the DrsObject.

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -122,12 +122,12 @@ paths:
                     description: array of strings that need to be passed with the URL to get bytes
       tags:
         - Objects
-  /datasets:
+  /cohorts:
     parameters:
       - $ref: '#/components/parameters/BearerAuth'
     get:
-      description: List all datasets available
-      operationId: drs_operations.list_datasets
+      description: List all cohorts available
+      operationId: drs_operations.list_cohorts
       responses:
         200:
           description: ok
@@ -137,42 +137,42 @@ paths:
                 type: array
                 items:
                   type: string
-                description: array of datasets
+                description: array of cohorts
     post:
-      description: Create a dataset
-      operationId: drs_operations.post_dataset
+      description: Create a cohort
+      operationId: drs_operations.post_cohort
       requestBody:
-          $ref: '#/components/requestBodies/DatasetRequest'
+          $ref: '#/components/requestBodies/CohortRequest'
       responses:
           200:
-            description: The `Dataset` was created successfully
+            description: The `Cohort` was created successfully
             content:
               application/json:
                   schema:
                     type: object
 
-  /datasets/{dataset_id}:
+  /cohorts/{cohort_id}:
     parameters:
-      - $ref: "#/components/parameters/DatasetId"
+      - $ref: "#/components/parameters/CohortId"
       - $ref: '#/components/parameters/BearerAuth'
     get:
-      description: Describe a dataset
-      operationId: drs_operations.get_dataset
+      description: Describe a cohort
+      operationId: drs_operations.get_cohort
       responses:
         200:
           description: ok
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Dataset'
+                $ref: '#/components/schemas/Cohort'
     delete:
-      summary: Delete a dataset.
+      summary: Delete a cohort.
       description: >-
-        Delete a dataset, and all associated DRS objects.
-      operationId: drs_operations.delete_dataset
+        Delete a cohort, and all associated DRS objects.
+      operationId: drs_operations.delete_cohort
       responses:
           200:
-            description: The dataset was deleted successfully
+            description: The cohort was deleted successfully
             content:
               application/json:
                 schema:
@@ -185,11 +185,11 @@ components:
       schema:
         type: string
         description: A string of the format 'Bearer <token>'
-    DatasetId:
+    CohortId:
       in: path
-      name: dataset_id
+      name: cohort_id
       required: true
-      description: DatasetId
+      description: CohortId
       schema:
         type: string
     ObjectId:
@@ -247,19 +247,19 @@ components:
               - $ref: "#/components/schemas/GenomicDrsObject"
               - $ref: "#/components/schemas/GenomicDataDrsObject"
               - $ref: "#/components/schemas/GenomicIndexDrsObject"
-    DatasetRequest:
+    CohortRequest:
       content:
         'application/json':
           schema:
-            $ref: '#/components/schemas/Dataset'
+            $ref: '#/components/schemas/Cohort'
 
   schemas:
-    Dataset:
+    Cohort:
       type: object
       properties:
         id:
           type: string
-          description: name of dataset
+          description: name of cohort
         drsobjects:
           type: array
           items:

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -49,8 +49,8 @@ def get_object(object_id, expand=False):
     return new_object, 200
 
 
-def list_objects():
-    return database.list_drs_objects(), 200
+def list_objects(cohort_id):
+    return database.list_drs_objects(cohort_id=cohort_id), 200
 
 
 @app.route('/ga4gh/drs/v1/objects/<object_id>/access_url/<path:access_id>')

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -105,44 +105,44 @@ def delete_object(object_id):
         return {"message": str(e)}, 500
 
 
-def list_datasets():
-    datasets = database.list_datasets()
-    if datasets is None:
+def list_cohorts():
+    cohorts = database.list_cohorts()
+    if cohorts is None:
         return [], 404
     try:
         if authz.is_site_admin(request):
-            return list(map(lambda x: x['id'], datasets)), 200
-        authorized_datasets = authz.get_authorized_datasets(request)
-        return list(set(map(lambda x: x['id'], datasets)).intersection(set(authorized_datasets))), 200
+            return list(map(lambda x: x['id'], cohorts)), 200
+        authorized_cohorts = authz.get_authorized_cohorts(request)
+        return list(set(map(lambda x: x['id'], cohorts)).intersection(set(authorized_cohorts))), 200
     except Exception as e:
         return [], 500
 
 
-def post_dataset():
+def post_cohort():
     if not authz.is_site_admin(request):
         return {"message": "User is not authorized to POST"}, 403
-    new_dataset = database.create_dataset(connexion.request.json)
-    return new_dataset, 200
+    new_cohort = database.create_cohort(connexion.request.json)
+    return new_cohort, 200
 
 
-def get_dataset(dataset_id):
-    new_dataset = database.get_dataset(dataset_id)
-    if new_dataset is None:
-        return {"message": "No matching dataset found"}, 404
+def get_cohort(cohort_id):
+    new_cohort = database.get_cohort(cohort_id)
+    if new_cohort is None:
+        return {"message": "No matching cohort found"}, 404
     if authz.is_site_admin(request):
-        return new_dataset, 200
-    authorized_datasets = authz.get_authorized_datasets(request)
-    if new_dataset["id"] in authorized_datasets:
-        return new_dataset, 200
-    return {"message": f"Not authorized to access dataset {dataset_id}"}, 403
+        return new_cohort, 200
+    authorized_cohorts = authz.get_authorized_cohorts(request)
+    if new_cohort["id"] in authorized_cohorts:
+        return new_cohort, 200
+    return {"message": f"Not authorized to access cohort {cohort_id}"}, 403
 
 
-def delete_dataset(dataset_id):
+def delete_cohort(cohort_id):
     if not authz.is_site_admin(request):
         return {"message": "User is not authorized to POST"}, 403
     try:
-        new_dataset = database.delete_dataset(dataset_id)
-        return new_dataset, 200
+        new_cohort = database.delete_cohort(cohort_id)
+        return new_cohort, 200
     except Exception as e:
         return {"message": str(e)}, 500
 

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -35,15 +35,21 @@ def get_headers(username=USERNAME, password=PASSWORD):
     return headers
 
 
-def test_remove_objects(drs_objects):
+def test_remove_objects():
+    cohorts = ["test-htsget", "1000Genomes"]
     headers = get_headers()
-    for obj in drs_objects:
-        url = f"{HOST}/ga4gh/drs/v1/objects/{obj['id']}"
+    for cohort in cohorts:
+        url = f"{HOST}/ga4gh/drs/v1/cohorts/{cohort}"
         response = requests.request("GET", url, headers=headers)
         if response.status_code == 200:
             response = requests.request("DELETE", url, headers=headers)
-            print(f"DELETE {obj['name']}: {response.text}")
+            print(f"DELETE {cohort}: {response.text}")
             assert response.status_code == 200
+        url = f"{HOST}/ga4gh/drs/v1/objects"
+        response = requests.request("GET", url, headers=headers, params={"cohort_id": cohort})
+        assert response.status_code == 200
+        for obj in response.json():
+            assert obj["cohort"] != cohort
 
 
 def test_post_objects(drs_objects):

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -127,6 +127,7 @@ def test_install_public_object():
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz.tbi",
             "size": 0,
             "version": "v1",
+            "cohort": "1000genomes",
             "access_methods": [
                 {
                     "type": "s3",
@@ -143,6 +144,7 @@ def test_install_public_object():
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",
             "size": 0,
             "version": "v1",
+            "cohort": "1000genomes",
             "access_methods": [
                 {
                     "type": "s3",
@@ -174,7 +176,8 @@ def test_install_public_object():
             "mime_type": "application/octet-stream",
             "name": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes",
             "size": 0,
-            "version": "v1"
+            "version": "v1",
+            "cohort": "1000genomes"
         }
     ]
     for obj in pieces:
@@ -206,7 +209,7 @@ def get_ingest_sample_names(genomic_id):
         ingest_map, program_id = item
         if ingest_map["genomic_id"] == genomic_id:
             for sample in ingest_map["samples"]:
-                result[sample['sample_name_in_file']] = f"{program_id}~{sample['sample_registration_id']}"
+                result[sample['sample_name_in_file']] = f"{sample['sample_registration_id']}"
     return result
 
 
@@ -225,7 +228,7 @@ def test_add_sample_drs(input, program_id):
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
     for sample in input['samples']:
-        sample_id = f"{program_id}~{sample['sample_registration_id']}"
+        sample_id = f"{sample['sample_registration_id']}"
         # remove any existing objects:
         sample_url = f"{HOST}/ga4gh/drs/v1/objects/{sample_id}"
         response = requests.request("GET", sample_url, headers=headers)
@@ -247,7 +250,8 @@ def test_add_sample_drs(input, program_id):
                     "id": input['genomic_id']
                 }
             ],
-            "version": "v1"
+            "version": "v1",
+            "cohort": program_id
         }
         response = requests.request("POST", post_url, json=sample_drs_object, headers=headers)
         print(f"POST {sample_drs_object['id']}: {response.text}")
@@ -518,7 +522,8 @@ def drs_objects():
             "mime_type": "application/octet-stream",
             "name": drs_obj,
             "contents": [],
-            "version": "v1"
+            "version": "v1",
+            "cohort": "test-htsget"
         }
         result.append(genomic_drs_obj)
 
@@ -529,7 +534,8 @@ def drs_objects():
             "description": "index",
             "mime_type": "application/octet-stream",
             "name": index_file,
-            "version": "v1"
+            "version": "v1",
+            "cohort": "test-htsget"
         })
         # add it to the contents of the genomic_drs_obj:
         genomic_drs_obj['contents'].append({
@@ -548,7 +554,8 @@ def drs_objects():
             "description": type,
             "mime_type": "application/octet-stream",
             "name": data_file,
-            "version": "v1"
+            "version": "v1",
+            "cohort": "test-htsget"
         })
         # add it to the contents of the genomic_drs_obj:
         genomic_drs_obj['contents'].append({

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,4 +9,4 @@ processes = 4
 gid = candig
 uid = candig
 
-harakiri = 30
+harakiri = 60


### PR DESCRIPTION
Dataset is renamed to Cohort throughout HTSGet. Every DRS object is now required to be ingested with a cohort ID, and each object is only associated with a single Cohort.

Integration tests are slightly broken until I update them to match, but pytest inside the container works fine:
```
docker exec -it candigv2_htsget_1 pytest
```