### PR TITLE
DIG-1301: finish delete cascades

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -464,6 +464,11 @@ def delete_drs_object(obj_id):
     with Session() as session:
         new_object = session.query(DrsObject).filter_by(id=obj_id).one()
         cohort = session.query(Cohort).filter_by(id=new_object.cohort_id).one_or_none()
+        if new_object.description in ["wgs", "wts"]:
+            # this is a GenomicDrsObject; we need to delete any indexed variantfiles
+            variantfiles = session.query(VariantFile).filter_by(drs_object_id=new_object.id).all()
+            for vf in variantfiles:
+                session.delete(vf)
         session.delete(new_object)
         session.commit()
         return json.loads(str(new_object))

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -126,7 +126,8 @@ class VariantFile(ObjectDBBase):
     # a variantfile can contain several samples
     samples = relationship(
         "Sample",
-        back_populates="variantfile"
+        back_populates="variantfile",
+        cascade="all, delete, delete-orphan"
     )
     def __repr__(self):
         result = {

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -49,7 +49,7 @@ def get_object(object_id, expand=False):
     return new_object, 200
 
 
-def list_objects(cohort_id):
+def list_objects(cohort_id=None):
     return database.list_drs_objects(cohort_id=cohort_id), 200
 
 

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -36,7 +36,7 @@ def get_headers(username=USERNAME, password=PASSWORD):
 
 
 def test_remove_objects():
-    cohorts = ["test-htsget", "1000Genomes"]
+    cohorts = ["test-htsget", "1000genomes"]
     headers = get_headers()
     for cohort in cohorts:
         url = f"{HOST}/ga4gh/drs/v1/cohorts/{cohort}"

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -204,7 +204,7 @@ def get_ingest_file():
                         "sample_name_in_file": "NA18537"
                     }
                 ]
-            }, "1000Genomes"
+            }, "1000genomes"
         )
     ]
 


### PR DESCRIPTION
I made a few tiny errors in the last PR, and then thought that I should check the delete cascades in related internal tables, like VariantFile and its associated table Sample. It's hard to check these in a test method, because there are no exposed APIs for them, but you can log in with psql and see that it works:

Run pytest in the container, as before, to populate the tables. Log into the database with psql and run `select * from sample;` to see what samples are present. Any that have an attached variantfile_id are the newly-created ones; you'll probably have orphans from previous runs.

Then run just `pytest -k 'test_remove_objects'`. If you look at the contents of the sample table in psql now, you should be missing those last few rows. 