### PR TITLE
DIG-1377: Be consistent in our use of candig user inside containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "candigv2"="htsget_app"
 
 USER root
 
-RUN useradd -r candig -U
+RUN addgroup -S candig && adduser -S candig -G candig
 
 RUN apt-get update && apt-get -y install \
 	cron \
@@ -23,6 +23,10 @@ RUN pip install --no-cache-dir -r /app/htsget_server/requirements.txt
 COPY . /app/htsget_server
 
 WORKDIR /app/htsget_server
+
+RUN chown -R candig:candig /app/htsget_server
+
+USER candig
 
 RUN touch initial_setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL "candigv2"="htsget_app"
 
 USER root
 
-RUN addgroup -S candig && adduser -S candig -G candig
+RUN groupadd -r candig && useradd -r candig -g candig
 
 RUN apt-get update && apt-get -y install \
 	cron \


### PR DESCRIPTION
## Tickets
[DIG-1377](https://candig.atlassian.net/browse/DIG-1377)

## Description

Adds the CanDIG user and group during the Dockerfile initialization, and makes sure that the stack is being run as the CanDIG user. This should ideally not change anything, and is only another layer of security (the root user in Docker is actually the same root as on your local filesystem? And we're just relying on Docker isolating the child process enough to prevent it from affecting things outside the container.) This is one PR out of six doing more-or-less the same thing.

[DIG-1377]: https://candig.atlassian.net/browse/DIG-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ