### PR TITLE
DIG-1463: Verify existence of genomic files

### DIFF
--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -52,6 +52,15 @@ def get_object(object_id, expand=False):
     return new_object, 200
 
 
+def get_object_for_drs_uri(drs_uri):
+    drs_uri_parse = re.match(r"drs:\/\/(.+)\/(.+)")
+    if drs_uri_parse is None:
+        return {"message": f"Incorrect format for DRS URI: {drs_uri}"}
+    if drs_uri_parse.group(1) == os.getenv("HTSGET_URL"):
+        return get_object(drs_uri_parse.group(2))
+    return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}
+
+
 def list_objects(cohort_id=None):
     return database.list_drs_objects(cohort_id=cohort_id), 200
 

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -222,7 +222,10 @@ def _get_file_path(drs_file_obj_id):
                         result['message'] = f"No file exists at {result['path']} on the server."
                         result['status_code'] = 404
     if result['path'] is None:
-        result['message'] = f"No file was found for drs_obj {drs_file_obj_id}: {url}"
+        message = url
+        if "error" in url:
+            message = url["error"]
+        result['message'] = f"No file was found for drs_obj {drs_file_obj_id}: {message}"
         result['status_code'] = 404
         result.pop('path')
     return result

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -216,10 +216,15 @@ def _get_file_path(drs_file_obj_id):
     for method in drs_file_obj["access_methods"]:
         if "access_id" in method and method["access_id"] != "":
             # we need to go to the access endpoint to get the url and file
-            (url, status_code) = _get_access_url(method["access_id"])
+            (url_obj, status_code) = _get_access_url(method["access_id"])
             result["status_code"] = status_code
             if status_code < 300:
-                result["path"] = url["url"]
+                result["path"] = url_obj["url"]
+                result["checksum"] = {
+                    "type": "etag",
+                    "checksum": url_obj["metadata"].etag
+                }
+                result["size"] = url_obj["metadata"].size
                 break
         else:
             # the access_url has all the info we need
@@ -230,6 +235,12 @@ def _get_file_path(drs_file_obj_id):
                     if not os.path.exists(result["path"]):
                         result['message'] = f"No file exists at {result['path']} on the server."
                         result['status_code'] = 404
+                    else:
+                        if len(drs_file_obj["checksums"]) > 0:
+                            result["checksum"] = drs_file_obj["checksums"][0]
+                        else:
+                            result["checksum"] = None
+                        result["size"] = os.path.getsize(result["path"])
     if result['path'] is None:
         message = url
         if "error" in url:
@@ -263,7 +274,7 @@ def _get_access_url(access_id):
                 public = True
             url, status_code = authz.get_s3_url(s3_endpoint=endpoint, bucket=bucket, object_id=object_name, access_key=access, secret_key=secret, public=public)
         if status_code == 200:
-            return {"url": url}, status_code
-        return {"error": url}, 500
+            return url, status_code
+        return url, 500
     else:
         return {"message": f"Malformed access_id {access_id}: should be in the form endpoint/bucket/item", "method": "_get_access_url"}, 400

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -206,6 +206,30 @@ paths:
                 5XX:
                     $ref: '#/components/responses/5xxServerError'
 
+    /variants/{id}/verify:
+        get:
+            tags:
+                - Variants
+            summary: Verify the integrity of the variant object
+            operationId: "htsget_operations.verify_genomic_drs_object"
+            description: |
+                Verify the integrity of the variant object
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+            responses:
+                200:
+                    description: Variant file stored correctly
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5XX:
+                    $ref: '#/components/responses/5xxServerError'
+
     /variants/data/{id}:
         get:
             tags:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -455,6 +455,8 @@ def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=N
 def _verify_genomic_drs_object(id_):
     # get the listed samples that the GenomicDrsObject says should be in the file
     gen_drs_obj, status_code = drs_operations.get_object(id_)
+    if status_code != 200:
+        raise Exception(f"Could not find object {id_}")
     drs_samples = set()
     if "contents" in gen_drs_obj and "reference_genome" in gen_drs_obj:
         for c in gen_drs_obj["contents"]:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -350,7 +350,7 @@ def _get_data(id_, reference_name=None, start=None, end=None, class_=None, forma
     gen_obj = drs_operations._get_genomic_obj(id_)
     if gen_obj is not None:
         if "message" in gen_obj:
-            return {"message": gen_obj['message']}, gen_obj['status_code']
+            return gen_obj['message'], gen_obj['status_code']
         file_in = gen_obj["file"]
         ntf = tempfile.NamedTemporaryFile(prefix='htsget', suffix=format_,
                                  mode='wb', delete=False)

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -111,6 +111,15 @@ def get_variants_data(id_, reference_name=None, format_="VCF", start=None, end=N
     return None, auth_code
 
 
+@app.route('/variants/<path:id_>/verify')
+def verify_genomic_drs_object(id_):
+    try:
+        _verify_genomic_drs_object(id_)
+    except Exception as e:
+        return {"result": False, "message": str(e)}, 200
+    return {"result": True}, 200
+
+
 @app.route('/variants/<path:id_>/index')
 def index_variants(id_=None, force=False, genome='hg38', genomic_id=None):
     if not authz.is_site_admin(request):
@@ -443,3 +452,25 @@ def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=N
     return {"message": f"No {file_type} found for id: {id}, try using the other endpoint"}, 404
 
 
+def _verify_genomic_drs_object(id_):
+    # get the listed samples that the GenomicDrsObject says should be in the file
+    gen_drs_obj, status_code = drs_operations.get_object(id_)
+    drs_samples = set()
+    if "contents" in gen_drs_obj and "reference_genome" in gen_drs_obj:
+        for c in gen_drs_obj["contents"]:
+            if c["id"] not in ["variant", "read", "index"]:
+                drs_samples.add(c["id"])
+    else:
+        raise Exception(f"Object {id_} is not a GenomicDrsObject")
+
+    # get the samples that are in the linked files
+    gen_obj = drs_operations._get_genomic_obj(id_)
+    if gen_obj is None:
+        raise Exception(f"No variant with id {id_} exists")
+    if "message" in gen_obj:
+        raise Exception(f"{gen_obj['message']}")
+    file_samples = set(gen_obj['file'].header.samples)
+    test = drs_samples.difference(file_samples)
+    if len(test) > 0:
+        raise Exception(f"GenomicDrsObject {id_} lists samples {test} that are not in the linked genomic file")
+    return None

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -150,9 +150,12 @@ def calculate_stats(obj_id):
 class IndexingHandler(watchdog.events.FileSystemEventHandler):
     def on_created(self, event):
         name = event.src_path.replace(INDEXING_PATH, "").replace("/", "")
-        response, status_code = index_variants(id_=name)
-        logging.info(response)
-        os.remove(event.src_path)
+        try:
+            response, status_code = index_variants(id_=name)
+            logging.info(response)
+            os.remove(event.src_path)
+        except Exception as e:
+            logging.warning(str(e))
 
 
 if __name__ == "__main__":
@@ -175,7 +178,10 @@ if __name__ == "__main__":
     to_index = os.listdir(INDEXING_PATH)
     logging.info(f"Finishing backlog: indexing {to_index}")
     while len(to_index) > 0:
-        index_variants(id_=to_index.pop())
+        try:
+            x=to_index.pop()
+            index_variants(id_=x)
+            os.remove(f"{INDEXING_PATH}/{x}")
         to_index = os.listdir(INDEXING_PATH)
 
     # now that the backlog is complete, listen for new files created:

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -8,6 +8,7 @@ import os
 import sys
 from watchdog.observers import Observer
 import watchdog.events
+import hashlib
 
 
 def index_variants(id_=None):
@@ -58,6 +59,11 @@ def index_variants(id_=None):
 
     database.mark_variantfile_as_indexed(id_)
     logging.info(f"{id_} done")
+
+    logging.info(f"adding stats to {id_}")
+    calculate_stats(id_)
+    logging.info(f"{id_} done")
+
     return {"message": f"Indexing complete for variantfile {id_}"}, 200
 
 
@@ -94,6 +100,49 @@ def create_position(obj):
     obj['normalized_contigs'] = normalized_contigs
     obj.pop('positions')
     return obj
+
+
+## Given a DrsObject in json, compute its size and checksums
+def calculate_stats(obj_id):
+    drs_json = database.get_drs_object(obj_id)
+    # a DrsObject either has access methods or contents
+    if "access_methods" in drs_json:
+        # if there are access methods, it's a file object
+        file_obj = drs_operations._get_file_path(drs_json["id"])
+        if file_obj["checksum"] is None:
+            logging.debug(f"calculating checksum for {drs_json['id']}")
+            checksum = []
+            with open(file_obj["path"], "rb") as f:
+                bytes = f.read()  # read file as bytes
+                checksum = [{
+                    "type": "sha-256",
+                    "checksum": hashlib.sha256(bytes).hexdigest()
+                }]
+            logging.debug(f"done calculating checksum for {drs_json['id']}")
+            drs_json["checksums"] = checksum
+        else:
+            drs_json["checksums"] = [file_obj["checksum"]]
+        drs_json["size"] = file_obj["size"]
+    elif "contents" in drs_json:
+        drs_json["size"] = 0
+        checksum = {
+            "type": "sha-256",
+            "checksum": ""
+        }
+        # if it's a sample drs object, its checksum will be ""
+        if drs_json["description"] != "sample":
+            # for each contents, find drs_obj for its drs_uri
+            raw_checksums = []
+            for c in drs_json["contents"]:
+                c_obj = calculate_stats(c["name"])
+                if len(c_obj["checksums"]) > 0:
+                    raw_checksums.append(c_obj["checksums"][0]["checksum"])
+                drs_json["size"] += c_obj["size"]
+            # sort raw checksums, concat, then take sha256:
+            raw_checksums.sort()
+            checksum["checksum"] = hashlib.sha256("".join(raw_checksums).encode()).hexdigest()
+        drs_json["checksums"] = [checksum]
+    return database.create_drs_object(drs_json)
 
 
 ## When a file is created, index the variant with the ID of that filename.

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -182,6 +182,8 @@ if __name__ == "__main__":
             x=to_index.pop()
             index_variants(id_=x)
             os.remove(f"{INDEXING_PATH}/{x}")
+        except Exception as e:
+            logging.warning(str(e))
         to_index = os.listdir(INDEXING_PATH)
 
     # now that the backlog is complete, listen for new files created:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.20.0
 sqlalchemy==1.4.44
 connexion==2.14.1
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/stat-object
 pytest==7.2.0
 uwsgi==2.0.22
 connexion[swagger-ui]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.20.0
 sqlalchemy==1.4.44
 connexion==2.14.1
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/stat-object
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.2
 pytest==7.2.0
 uwsgi==2.0.22
 connexion[swagger-ui]

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -286,6 +286,10 @@ def test_add_sample_drs(input, program_id):
         assert response.status_code == 200
     assert len(genomic_drs_obj["contents"]) == contents_count + 1
 
+    verify_url = f"{HOST}/htsget/v1/variants/{input['genomic_id']}/verify"
+    response = requests.get(verify_url)
+    assert response.status_code == 200
+
 
 @pytest.mark.parametrize('input, program_id', get_ingest_file())
 def test_sample_stats(input, program_id):

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -116,6 +116,8 @@ def test_index_variantfile(sample, genomic_id):
     response = requests.get(get_url, headers=get_headers())
     print(response.text)
     assert response.json()["indexed"] == 1
+    assert len(response.json()["checksums"]) > 0
+    assert response.json()["size"] > 0
 
 
 def test_install_public_object():


### PR DESCRIPTION
Added endpoint to verify existence of the files linked in a GenomicDrsObject. This method attempts to open the genomic file and get the samples listed; if it can do so, it compares the samples to the ones listed in the GenomicDrsObject. It returns `{"result": True}` if this all matches up and `{"result": False, "message": error message}` if not. The test in here is not very robust because htsget itself doesn't deal with samples very much: this is tested for real in test_integration.

Bonus: I have never bothered to add checksums and file sizes to DrsObjects as I should, based on the specification. Now that we've broken indexing out into a background process, I've hooked into that method to calculate checksums and sizes. This is now also tested in test_index_variantfile (which is run in test_integration as well).