### PR TITLE
Reverting #239: Remove variantfile's optional genomic_id field

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -37,3 +37,8 @@ if [[ $numgenes -lt 5 ]]; then
     # rm genes.sql
     echo "...done"
 fi
+
+# run any migrations:
+echo "running migrations..."
+psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_288.sql >>setup_out.txt
+echo "...done"

--- a/data/files.sql
+++ b/data/files.sql
@@ -131,7 +131,6 @@ INSERT INTO alias VALUES('chrM','MT');
 INSERT INTO alias VALUES('ChrM','MT');
 CREATE TABLE variantfile (
 	id VARCHAR NOT NULL,
-	genomic_id VARCHAR,
 	drs_object_id VARCHAR,
 	indexed INTEGER,
 	chr_prefix VARCHAR,
@@ -250,8 +249,5 @@ INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos
 INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000023.10', 'X', 0, 0, '') ON CONFLICT DO NOTHING;
 INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000024.9', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
 INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
-
--- reverting https://github.com/CanDIG/htsget_app/pull/239
-ALTER TABLE variantfile DROP COLUMN genomic_id;
 
 COMMIT;

--- a/data/files.sql
+++ b/data/files.sql
@@ -251,4 +251,7 @@ INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos
 INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_000024.9', 'Y', 0, 0, '') ON CONFLICT DO NOTHING;
 INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES ('hg37', 'NC_012920.1', 'MT', 0, 0, '') ON CONFLICT DO NOTHING;
 
+-- reverting https://github.com/CanDIG/htsget_app/pull/239
+ALTER TABLE variantfile DROP COLUMN genomic_id;
+
 COMMIT;

--- a/data/pr_288.sql
+++ b/data/pr_288.sql
@@ -1,0 +1,9 @@
+-- reverting https://github.com/CanDIG/htsget_app/pull/239
+DO
+$$
+    BEGIN
+        ALTER TABLE variantfile DROP COLUMN genomic_id;
+    EXCEPTION
+        WHEN undefined_column THEN
+     END;
+$$;

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -92,7 +92,6 @@ class Contig(ObjectDBBase):
 class VariantFile(ObjectDBBase):
     __tablename__ = 'variantfile'
     id = Column(String, primary_key=True)
-    genomic_id = Column(String)
     indexed = Column(Integer)
     chr_prefix = Column(String)
     reference_genome = Column(String)
@@ -133,7 +132,6 @@ class VariantFile(ObjectDBBase):
         result = {
             'id': self.id,
             'drsobject': self.drs_object_id,
-            'genomic_id': self.genomic_id,
             'indexed': self.indexed,
             'chr_prefix': self.chr_prefix,
             'reference_genome': self.reference_genome,
@@ -579,7 +577,7 @@ def get_variantfile(variantfile_id):
 
 
 def create_variantfile(obj):
-    # obj = {"id", "reference_genome", "genomic_id"}
+    # obj = {"id", "reference_genome"}
     with Session() as session:
         new_variantfile = session.query(VariantFile).filter_by(id=obj['id']).one_or_none()
         if new_variantfile is None:
@@ -587,10 +585,6 @@ def create_variantfile(obj):
             new_variantfile.indexed = 0
             new_variantfile.chr_prefix = ''
         new_variantfile.id = obj['id']
-        if "genomic_id" in obj:
-            new_variantfile.genomic_id = obj['genomic_id']
-        else:
-            new_variantfile.genomic_id = obj['id']
         new_variantfile.reference_genome = obj['reference_genome']
         new_drs = session.query(DrsObject).filter_by(id=obj['id']).one_or_none()
         if new_drs is not None:

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -191,7 +191,6 @@ paths:
                 - $ref: '#/components/parameters/idPathParam'
                 - $ref: '#/components/parameters/forceParam'
                 - $ref: '#/components/parameters/refGenomeParam'
-                - $ref: '#/components/parameters/genomicIdParam'
             responses:
                 200:
                     description: Successfully indexed variant file
@@ -884,13 +883,6 @@ components:
             required: false
             schema:
                 $ref: '#/components/schemas/ReferenceGenome'
-        genomicIdParam:
-            in: query
-            name: genomic_id
-            description: If specified, sets this variant entity's associated genomic_id. Otherwise default is the same as the id.
-            required: false
-            schema:
-                type: string
         sampleIdPathParam:
             in: path
             name: id

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -121,13 +121,11 @@ def verify_genomic_drs_object(id_):
 
 
 @app.route('/variants/<path:id_>/index')
-def index_variants(id_=None, force=False, genome='hg38', genomic_id=None):
+def index_variants(id_=None, force=False, genome='hg38'):
     if not authz.is_site_admin(request):
         return {"message": "User is not authorized to index variants"}, 403
     if id_ is not None:
         params = {"id": id_, "reference_genome": genome}
-        if genomic_id is not None:
-            params["genomic_id"] = genomic_id
         try:
             varfile = database.create_variantfile(params)
             if varfile is not None:

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -97,15 +97,13 @@ def test_post_update():
 
 
 def index_variants():
-    return [('sample.compressed', None), ('NA18537', None), ('multisample_1', 'HG00096'), ('multisample_2', 'HG00097'), ('test', 'BIOCAN_00097')]
+    return [('sample.compressed'), ('NA18537'), ('multisample_1'), ('multisample_2'), ('test')]
 
 
-@pytest.mark.parametrize('sample, genomic_id', index_variants())
-def test_index_variantfile(sample, genomic_id):
+@pytest.mark.parametrize('sample', index_variants())
+def test_index_variantfile(sample):
     url = f"{HOST}/htsget/v1/variants/{sample}/index"
     params = {}
-    if genomic_id is not None:
-        params["genomic_id"] = genomic_id
     params['force'] = True
     response = requests.get(url, params=params, headers=get_headers())
     assert response.status_code == 200


### PR DESCRIPTION
As far as I can tell, this field was added as a bit of a hack back when we thought we would need an explicit, separate table matching katsu entities (mcode at the time) to their genomic files in htsget. (maybe explained [here](https://candig.slack.com/archives/C02TJS4J96U/p1666981383862699)?) It doesn't ever seem to be used outside of these tests, and now that we're definitely not using it in indexing on ingest, I think we can remove it. It's just very confusing because we use the term `genomic_id` in other contexts as well.