### PR TITLE
DIG-1486, DIG-1487: Informative handling of indexing failures

### DIFF
--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -44,6 +44,15 @@ def get_authorized_cohorts(request):
         return []
 
 
+def is_cohort_authorized(request, cohort_id):
+    if is_site_admin(request):
+        return True
+    authorized_cohorts = get_authorized_cohorts(request)
+    if cohort_id in authorized_cohorts:
+        return True
+    return False
+
+
 def is_site_admin(request):
     """
     Is the user associated with the token a site admin?

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -179,6 +179,20 @@ paths:
               application/json:
                 schema:
                   type: object
+  /cohorts/{cohort_id}/status:
+    parameters:
+      - $ref: "#/components/parameters/CohortId"
+      - $ref: '#/components/parameters/BearerAuth'
+    get:
+      description: List indexing status reports for a cohort
+      operationId: drs_operations.get_cohort_status
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CohortIndexStatus'
 components:
   parameters:
     BearerAuth:
@@ -271,8 +285,35 @@ components:
         drsobjects:
           type: array
           items:
-            type: string
-            description: a DRS object's self_uri
+            $ref: '#/components/schemas/DrsUri'
+    CohortIndexStatus:
+      type: object
+      properties:
+        index_complete:
+          description: DrsUris for variant genomic objects that have been successfully indexed
+          type: array
+          items:
+            $ref: '#/components/schemas/DrsUri'
+        index_in_progress:
+          description: DrsUris for variant genomic objects that have not yet been indexed
+          type: array
+          items:
+            $ref: '#/components/schemas/DrsUri'
+        index_errored:
+          description: DrsUris for variant genomic objects that are in the queue to be indexed
+          type: array
+          items:
+            type: object
+            properties:
+              drs_uri:
+                $ref: '#/components/schemas/DrsUri'
+              errors:
+                type: array
+                items:
+                  type: string
+    DrsUri:
+      type: string
+      description: a DRS object's self_uri
     SampleDrsObject:
       type: object
       description: A DrsObject that describes the clinical sample used for genomic analysis.

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -8,6 +8,7 @@ import authz
 from markupsafe import escape
 from pysam import VariantFile, AlignmentFile
 from urllib.parse import parse_qs, urlparse, urlencode
+from config import INDEXING_PATH
 
 
 app = Flask(__name__)
@@ -53,10 +54,10 @@ def get_object(object_id, expand=False):
 
 
 def get_object_for_drs_uri(drs_uri):
-    drs_uri_parse = re.match(r"drs:\/\/(.+)\/(.+)")
+    drs_uri_parse = re.match(r"drs:\/\/(.+)\/(.+)", drs_uri)
     if drs_uri_parse is None:
         return {"message": f"Incorrect format for DRS URI: {drs_uri}"}
-    if drs_uri_parse.group(1) == os.getenv("HTSGET_URL"):
+    if drs_uri_parse.group(1) in os.getenv("HTSGET_URL"):
         return get_object(drs_uri_parse.group(2))
     return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}
 
@@ -132,6 +133,42 @@ def delete_cohort(cohort_id):
         return new_cohort, 200
     except Exception as e:
         return {"message": str(e)}, 500
+
+
+def get_cohort_status(cohort_id):
+    new_cohort = database.get_cohort(cohort_id)
+    if new_cohort is None:
+        return {"message": "No matching cohort found"}, 404
+    if not authz.is_cohort_authorized(request, cohort_id):
+        return {"message": f"Not authorized to access cohort {cohort_id}"}, 403
+
+    # get the objects in the cohort:
+    result = {
+        "index_complete": [],
+        "index_in_progress": [],
+        "index_errored": []
+    }
+    for drs_uri in new_cohort['drsobjects']:
+        drs_obj, status_code = get_object_for_drs_uri(drs_uri)
+        if "indexed" in drs_obj:
+            if drs_obj['indexed'] == 1:
+                result['index_complete'].append(drs_uri)
+            else:
+                # look for index touch file, see if there are errors there:
+                file_path = os.path.join(INDEXING_PATH, f"{cohort_id}_{drs_obj['id']}")
+                err_obj = {
+                    "drs_uri": drs_uri,
+                    "errors": []
+                }
+                if os.path.exists(file_path):
+                    with open(file_path) as f:
+                        err_obj["errors"].extend(f.readlines())
+                        if len(err_obj["errors"]) > 0:
+                            result['index_errored'].append(err_obj)
+                        else:
+                            result['index_in_progress'].append(drs_uri)
+    return result, 200
+
 
 # This is specific to our particular use case: a DRS object that represents a
 # particular sample can have a variant or read file and an associated index file.

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -242,9 +242,9 @@ def _get_file_path(drs_file_obj_id):
                             result["checksum"] = None
                         result["size"] = os.path.getsize(result["path"])
     if result['path'] is None:
-        message = url
-        if "error" in url:
-            message = url["error"]
+        message = url_obj
+        if "error" in url_obj:
+            message = url_obj["error"]
         result['message'] = f"No file was found for drs_obj {drs_file_obj_id}: {message}"
         result['status_code'] = 404
         result.pop('path')

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -183,6 +183,7 @@ def _get_genomic_obj(object_id):
     if 'message' in index_result:
         result = index_result
     else:
+        result['type'] = drs_obj['type']
         main_result = _get_file_path(drs_obj['main'])
         if 'message' in main_result:
             result = main_result

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -56,10 +56,10 @@ def get_object(object_id, expand=False):
 def get_object_for_drs_uri(drs_uri):
     drs_uri_parse = re.match(r"drs:\/\/(.+)\/(.+)", drs_uri)
     if drs_uri_parse is None:
-        return {"message": f"Incorrect format for DRS URI: {drs_uri}"}
+        return {"message": f"Incorrect format for DRS URI: {drs_uri}"}, 401
     if drs_uri_parse.group(1) in os.getenv("HTSGET_URL"):
         return get_object(drs_uri_parse.group(2))
-    return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}
+    return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}, 401
 
 
 def list_objects(cohort_id=None):

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -127,6 +127,30 @@ paths:
                5XX:
                    $ref: '#/components/responses/5xxServerError'
 
+    /reads/{id}/verify:
+       get:
+           tags:
+               - Reads
+           summary: Verify the integrity of the read object
+           operationId: "htsget_operations.verify_reads_genomic_drs_object"
+           description: |
+               Verify the integrity of the read object
+           parameters:
+               - $ref: '#/components/parameters/idPathParam'
+           responses:
+               200:
+                   description: Read file stored correctly
+                   content:
+                       application/json:
+                           schema:
+                               type: object
+               400:
+                   $ref: '#/components/responses/400BadRequestError'
+               404:
+                   $ref: '#/components/responses/404NotFoundError'
+               5XX:
+                   $ref: '#/components/responses/5xxServerError'
+
     /variants/service-info:
        get:
            tags:
@@ -210,7 +234,7 @@ paths:
             tags:
                 - Variants
             summary: Verify the integrity of the variant object
-            operationId: "htsget_operations.verify_genomic_drs_object"
+            operationId: "htsget_operations.verify_variants_genomic_drs_object"
             description: |
                 Verify the integrity of the variant object
             parameters:

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -127,6 +127,29 @@ paths:
                5XX:
                    $ref: '#/components/responses/5xxServerError'
 
+    /reads/{id}/index:
+      get:
+          tags:
+              - Reads
+          summary: Calculate size and checksums for the read object
+          operationId: "htsget_operations.index_reads"
+          description: Calculate size and checksums for the read object
+          parameters:
+              - $ref: '#/components/parameters/idPathParam'
+          responses:
+              200:
+                  description: Read file queued for indexing
+                  content:
+                      application/json:
+                          schema:
+                              type: object
+              400:
+                  $ref: '#/components/responses/400BadRequestError'
+              404:
+                  $ref: '#/components/responses/404NotFoundError'
+              5XX:
+                  $ref: '#/components/responses/5xxServerError'
+
     /reads/{id}/verify:
        get:
            tags:
@@ -217,7 +240,7 @@ paths:
                 - $ref: '#/components/parameters/refGenomeParam'
             responses:
                 200:
-                    description: Successfully indexed variant file
+                    description: Variant file queued for indexing
                     content:
                         application/json:
                             schema:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -134,13 +134,20 @@ def index_variants(id_=None, force=False, genome='hg38'):
     if not authz.is_site_admin(request):
         return {"message": "User is not authorized to index variants"}, 403
     if id_ is not None:
+        # check that there is a database drs object for this:
+        drs_obj = database.get_drs_object(id_)
+        if drs_obj is None:
+            return {"message": f"No DRS object exists with ID {id_}"}, 404
+        cohort = ""
+        if "cohort" in drs_obj:
+            cohort = drs_obj['cohort']
         params = {"id": id_, "reference_genome": genome}
         try:
             varfile = database.create_variantfile(params)
             if varfile is not None:
                 if varfile['indexed'] == 1 and not force:
                     return varfile, 200
-            Path(f"{INDEXING_PATH}/{id_}").touch()
+            Path(f"{INDEXING_PATH}/{cohort}_{id_}").touch()
             return None, 200
         except Exception as e:
             return {"message": str(e)}, 500

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -87,6 +87,27 @@ def get_reads_data(id_, reference_name=None, format_="bam", start=None, end=None
     return None, auth_code
 
 
+@app.route('/reads/<path:id_>/index')
+def index_reads(id_=None):
+    if not authz.is_site_admin(request):
+        return {"message": "User is not authorized to index reads"}, 403
+    if id_ is not None:
+        # check that there is a database drs object for this:
+        drs_obj = database.get_drs_object(id_)
+        if drs_obj is None:
+            return {"message": f"No DRS object exists with ID {id_}"}, 404
+        cohort = ""
+        if "cohort" in drs_obj:
+            cohort = drs_obj['cohort']
+        try:
+            Path(f"{INDEXING_PATH}/{cohort}_{id_}").touch()
+            return None, 200
+        except Exception as e:
+            return {"message": str(e)}, 500
+    else:
+        return None, 404
+
+
 @app.route('/reads/<path:id_>/verify')
 def verify_reads_genomic_drs_object(id_):
     try:

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -22,13 +22,20 @@ def index_variants(file_name=None):
     else:
         return {"message": f"Format of file name is wrong: {file_name}"}, 500
 
-    logging.info(f"{drs_obj_id} starting indexing")
+    logging.info(f"adding stats to {drs_obj_id}")
+    calculate_stats(drs_obj_id)
+    logging.info(f"{drs_obj_id} stats done")
 
     gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
     if gen_obj is None:
         return {"message": f"No variant with id {drs_obj_id} exists"}, 404
     if "message" in gen_obj:
         return {"message": gen_obj['message']}, 500
+
+    if gen_obj['type'] == 'read':
+        return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
+
+    logging.info(f"{drs_obj_id} starting indexing")
 
     headers = str(gen_obj['file'].header).split('\n')
 
@@ -69,10 +76,6 @@ def index_variants(file_name=None):
     database.create_pos_bucket(res)
 
     database.mark_variantfile_as_indexed(drs_obj_id)
-    logging.info(f"{drs_obj_id} done")
-
-    logging.info(f"adding stats to {drs_obj_id}")
-    calculate_stats(drs_obj_id)
     logging.info(f"{drs_obj_id} done")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -10,6 +10,7 @@ from watchdog.observers import Observer
 import watchdog.events
 import hashlib
 import re
+import datetime
 
 
 def index_variants(file_name=None):
@@ -161,9 +162,14 @@ def index_touch_file(file_path):
     try:
         name = file_path.replace(INDEXING_PATH, "").replace("/", "")
         response, status_code = index_variants(file_name=name)
+        if status_code != 200:
+            with open(file_path, "a") as f:
+                f.write(f"{datetime.datetime.today()} {response['message']}")
         logging.info(response)
         os.remove(file_path)
     except Exception as e:
+        with open(file_path, "a") as f:
+            f.write(f"{datetime.datetime.today()} {str(e)}")
         logging.warning(str(e))
 
 

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -9,27 +9,37 @@ import sys
 from watchdog.observers import Observer
 import watchdog.events
 import hashlib
+import re
 
 
-def index_variants(id_=None):
-    logging.info(f"{id_} starting indexing")
-    gen_obj = drs_operations._get_genomic_obj(id_)
+def index_variants(file_name=None):
+    # split file name into cohort and drs_obj_id
+    file_parse = re.match(r"(.*?)_(.+)", file_name)
+    if file_parse is not None:
+        cohort = file_parse.group(1)
+        drs_obj_id = file_parse.group(2)
+    else:
+        return {"message": f"Format of file name is wrong: {file_name}"}, 500
+
+    logging.info(f"{drs_obj_id} starting indexing")
+
+    gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
     if gen_obj is None:
-        return {"message": f"No variant with id {id_} exists"}, 404
+        return {"message": f"No variant with id {drs_obj_id} exists"}, 404
     if "message" in gen_obj:
         return {"message": gen_obj['message']}, 500
 
     headers = str(gen_obj['file'].header).split('\n')
 
-    database.add_header_for_variantfile({'texts': headers, 'variantfile_id': id_})
-    logging.info(f"{id_} indexed {len(headers)} headers")
+    database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
+    logging.info(f"{drs_obj_id} indexed {len(headers)} headers")
 
     samples = list(gen_obj['file'].header.samples)
     for sample in samples:
-        if database.create_sample({'id': sample, 'variantfile_id': id_}) is None:
-            logging.warning(f"Could not add sample {sample} to variantfile {id_}")
+        if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
+            logging.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-    logging.info(f"{id_} indexed {len(samples)} samples in file")
+    logging.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
 
     contigs = {}
     for contig in list(gen_obj['file'].header.contigs):
@@ -39,32 +49,32 @@ def index_variants(id_=None):
     for raw_contig in contigs.keys():
         if contigs[raw_contig] is not None:
             prefix = database.get_contig_prefix(raw_contig)
-            varfile = database.set_variantfile_prefix({"variantfile_id": id_, "chr_prefix": prefix})
+            varfile = database.set_variantfile_prefix({"variantfile_id": drs_obj_id, "chr_prefix": prefix})
             break
 
     positions = []
     normalized_contigs = []
-    to_create = {'variantfile_id': id_, 'positions': positions, 'normalized_contigs': normalized_contigs}
+    to_create = {'variantfile_id': drs_obj_id, 'positions': positions, 'normalized_contigs': normalized_contigs}
     for record in gen_obj['file'].fetch():
         normalized_contig_id = contigs[record.contig]
         if normalized_contig_id is not None:
             positions.append(record.pos)
             normalized_contigs.append(normalized_contig_id)
         else:
-            logging.warning(f"referenceName {record.contig} in {id_} does not correspond to a known chromosome.")
+            logging.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
     res = create_position(to_create)
 
-    logging.info(f"{id_} writing {len(res['bucket_counts'])} entries to db")
+    logging.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
     database.create_pos_bucket(res)
 
-    database.mark_variantfile_as_indexed(id_)
-    logging.info(f"{id_} done")
+    database.mark_variantfile_as_indexed(drs_obj_id)
+    logging.info(f"{drs_obj_id} done")
 
-    logging.info(f"adding stats to {id_}")
-    calculate_stats(id_)
-    logging.info(f"{id_} done")
+    logging.info(f"adding stats to {drs_obj_id}")
+    calculate_stats(drs_obj_id)
+    logging.info(f"{drs_obj_id} done")
 
-    return {"message": f"Indexing complete for variantfile {id_}"}, 200
+    return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 
 
 def create_position(obj):
@@ -151,7 +161,7 @@ class IndexingHandler(watchdog.events.FileSystemEventHandler):
     def on_created(self, event):
         name = event.src_path.replace(INDEXING_PATH, "").replace("/", "")
         try:
-            response, status_code = index_variants(id_=name)
+            response, status_code = index_variants(file_name=name)
             logging.info(response)
             os.remove(event.src_path)
         except Exception as e:
@@ -169,8 +179,15 @@ if __name__ == "__main__":
 
     ## If this has been called on a single ID, index it and exit.
     if args.id is not None:
+        drs_obj = database.get_drs_object(args.id)
+        if drs_obj is None:
+            print(f"No DRS object with id {args.id}")
+            sys.exit()
+        cohort = ""
+        if "cohort" in drs_obj:
+            cohort = drs_obj["cohort"]
         varfile = database.create_variantfile({"id": args.id, "reference_genome": args.genome})
-        index_variants(id_=args.id)
+        index_variants(drs_obj_id=f"{cohort}_{args.id}")
         sys.exit()
 
     ## Otherwise, look for any backlog IDs, index those, then listen for new IDs to index.
@@ -180,7 +197,7 @@ if __name__ == "__main__":
     while len(to_index) > 0:
         try:
             x=to_index.pop()
-            index_variants(id_=x)
+            index_variants(file_name=x)
             os.remove(f"{INDEXING_PATH}/{x}")
         except Exception as e:
             logging.warning(str(e))


### PR DESCRIPTION
The main change is the addition of the `/cohorts/{cohort_id}/status` endpoint. This returns the indexing status of a cohort, which is presumably the unit of ingestion and what a data custodian would be interested in. I didn't add any test here, but will add one in CanDIGv2.

I also added verification for reads files and "indexing" for them (which is, at this point, only calculating checksums and size stats).