### PR TITLE
DIG-1404: add variants and reads to sample

### DIFF
--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -865,6 +865,17 @@ components:
                     description: An array of associated GenomicDrsObjects that describe transcriptome data.
                     items:
                         type: string
+                variants:
+                    type: array
+                    description: An array of associated GenomicDataDrsObjects that describe variant files.
+                    items:
+                        type: string
+                reads:
+                    type: array
+                    description: An array of associated GenomicDataDrsObjects that describe read files.
+                    items:
+                        type: string
+
 
         # ERROR SCHEMAS
         Error:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -238,7 +238,9 @@ def get_sample(id_=None):
     result = {
         "sample_id": id_,
         "genomes": [],
-        "transcriptomes": []
+        "transcriptomes": [],
+        "variants": [],
+        "reads": []
     }
 
     # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
@@ -252,6 +254,13 @@ def get_sample(id_=None):
                     result["genomes"].append(drs_obj["id"])
                 elif drs_obj["description"] == "wts":
                     result["transcriptomes"].append(drs_obj["id"])
+                # check the contents of this genomic drs object and see if it contains variants or reads
+                if "contents" in drs_obj:
+                    for content in drs_obj["contents"]:
+                        if content["id"] == "variant":
+                            result["variants"].append(drs_obj["id"])
+                        elif content["id"] == "read":
+                            result["reads"].append(drs_obj["id"])
         return result, 200
     return {"message": f"Could not find sample {id_}"}, 404
 


### PR DESCRIPTION
For discovery queries, one might want to know if a sample is associated with any variant or read objects.

To test, pull your local candig-ingest submodule to latest develop (I tweaked genomic-ingest.json so that both a read and a variant were associated with the same sample in the same cohort).

Run ingest on that genomic-ingest.json file.

Run `curl "http://candig.docker.internal:5080/genomics/htsget/v1/samples/SPECIMEN_5"` with either user token (it's in SYNTHETIC-1).

You should get
```
{
  "genomes": [
    "multisample_1",
    "NA02102"
  ],
  "reads": [
    "NA02102"
  ],
  "sample_id": "SPECIMEN_5",
  "transcriptomes": [],
  "variants": [
    "multisample_1"
  ]
}
```