### PR TITLE
hotfix: biosampleId includes cohort, as documented in beacon yaml

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -396,7 +396,7 @@ def compile_beacon_resultset(variants_by_obj, reference_genome="hg38"):
                     # check to see that we should be processing the actual sample data:
                     if is_authed:
                         cld['analysisId'] = drs_obj
-                        cld['biosampleId'] = k
+                        cld['biosampleId'] = f"{x['cohort']}~{k}"
                     alleles = sample['GT'].split('/')
                     if len(alleles) < 2:
                         alleles = sample['GT'].split('|')


### PR DESCRIPTION
Discussed [here](https://candig.slack.com/archives/C01030VMCUR/p1709245809731199?thread_ts=1709237030.375739&cid=C01030VMCUR) and [here](https://candig.slack.com/archives/C01030VMCUR/p1709245641632849):

Because of a very hacky assumption on my part between htsget and ingest, at some point I assumed that ingest was going to tag all genomic objects with their cohorts as part of their sample names, separated with a tilde. We then decided to make cohort a mandatory field for all DRS objects, so that their sample names would just be the sample name. I forgot, though, to update the beacon output to wrap the cohort name back in.

So here we make it explicit: as it says in the beacon_openapi.yaml, "Reference to biosample ID (`biosample.id`). For MoH, this will be `{program_id}~{submitter_sample_id}`, delimited with a tilde."