### PR TITLE
DIG-1511: Query beacon results should only return authorized results

### DIFF
--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -15,8 +15,6 @@ def is_authed(id_, request):
         print("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         app.logger.warning("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         return 200 # no auth
-    if is_site_admin(request):
-        return 200
     if "Authorization" in request.headers:
         authed_cohorts = get_authorized_cohorts(request)
         obj = database.get_drs_object(id_)

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -279,8 +279,8 @@ def search(raw_req):
         response['beaconHandovers'] = []
         query_info = {} # program_id and submitter_sample_id
         for drs_obj_id in variants_by_file.keys():
-            # look for samples and cohorts
-            drs_obj, status_code = drs_operations.get_object(drs_obj_id)
+            # look for samples and cohorts for all drs objects, even if user is not authorized
+            drs_obj = database.get_drs_object(drs_obj_id)
             if "cohort" in drs_obj:
                 if drs_obj["cohort"] not in query_info:
                     query_info[drs_obj["cohort"]] = []

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -44,9 +44,6 @@ def get_object(object_id, expand=False):
         new_object = database.get_drs_object(escape(object_id), expand)
         auth_code = authz.is_authed(escape(object_id), request)
         if auth_code != 200:
-            # allow request if it's from query
-            if authz.request_is_from_query(request):
-                return new_object, 200
             return {"message": f"Not authorized to access object {object_id}"}, auth_code
     if new_object is None:
         return {"message": "No matching object found"}, 404

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -36,10 +36,14 @@ def get_headers(username=USERNAME, password=PASSWORD):
     return headers
 
 
-def test_remove_objects():
-    cohorts = ["test-htsget", "1000genomes"]
+def test_remove_objects(cohorts):
     headers = get_headers()
+    candig_url = os.getenv("CANDIG_URL")
+
     for cohort in cohorts:
+        if candig_url is not None:
+            response = requests.delete(f"{candig_url}/ingest/program/{cohort}/email/{USERNAME}@test.ca", headers=get_headers())
+
         url = f"{HOST}/ga4gh/drs/v1/cohorts/{cohort}"
         response = requests.request("GET", url, headers=headers)
         if response.status_code == 200:
@@ -53,13 +57,20 @@ def test_remove_objects():
             assert obj["cohort"] != cohort
 
 
-def test_post_objects(drs_objects):
+def test_post_objects(drs_objects, cohorts):
     """
     Install test objects. Will fail if any post request returns an error.
     """
     # clean up old objects in db:
     url = f"{HOST}/ga4gh/drs/v1/objects"
     headers = get_headers()
+    candig_url = os.getenv("CANDIG_URL")
+
+    for cohort in cohorts:
+        if candig_url is not None:
+            response = requests.post(f"{candig_url}/ingest/program/{cohort}/email/{USERNAME}@test.ca", headers=get_headers())
+            print(response.text)
+
     response = requests.request("GET", url, headers=headers)
 
     for obj in drs_objects:
@@ -510,6 +521,11 @@ def test_vcf_json():
     res = requests.request("GET", url, params=params, headers=get_headers())
     assert res.json()['id'] == 'test'
     assert len(res.json()['variants']) == 7
+
+
+@pytest.fixture
+def cohorts():
+    return ["test-htsget", "1000genomes"]
 
 
 @pytest.fixture


### PR DESCRIPTION
I actually found a bigger, long-ago bug while investigating this: Long ago, I'd assumed that site admins should be able to see all objects in all cohorts; for example, in our usual tests, user2 would be able to see things from SYNTHETIC-1 and SYNTHETIC-2, even if it is only explicitly authorized for SYNTHETIC-2. This is now fixed.

Anyway: now if you try to replicate the conditions in https://candig.atlassian.net/browse/DIG-1510, you should get the correct results.

I also had to tweak tests to add the test cohorts to Opa, if Opa is available (i.e. CANDIG_URL is available). This is required for integration tests, which were overly reliant on the site admin user being able to see everything.

NB: if you want to run integration tests on your system and have them pass after this, you'll need to pull https://github.com/CanDIG/CanDIGv2/pull/478 and also make sure your version of Opa has pulled https://github.com/CanDIG/candig-opa/pull/49.

To sum up: make sure you've pulled opa to develop, then do `make clean-opa; make docker-volumes; make build-opa; make compose-opa`. Then rebuild htsget and then run integration tests.