### PR TITLE
Fix tests to match https://github.com/CanDIG/CanDIGv2/pull/527

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.20.0
 sqlalchemy==1.4.44
 connexion==2.14.1
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.2.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/site-admin-user
 pytest==7.2.0
 uwsgi==2.0.22
 connexion[swagger-ui]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.20.0
 sqlalchemy==1.4.44
 connexion==2.14.1
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/site-admin-user
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.2.2
 pytest==7.2.0
 uwsgi==2.0.22
 connexion[swagger-ui]

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -17,8 +17,7 @@ from config import PORT
 
 HOST = os.getenv("TESTENV_URL", f"http://localhost:{PORT}")
 TEST_KEY = os.environ.get("HTSGET_TEST_KEY")
-USERNAME = os.getenv("CANDIG_SITE_ADMIN_USER")
-PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD")
+USERNAME = os.getenv("CANDIG_NOT_ADMIN_USER2", "user2@test.ca")
 MINIO_URL = os.getenv("MINIO_URL")
 VAULT_URL = os.getenv("VAULT_URL")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY")

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -70,8 +70,8 @@ def test_post_objects(drs_objects, cohorts):
         if candig_url is not None:
             test_program = {
                 "program_id": cohort,
-                "program_curators": [f"{USERNAME}@test.ca"],
-                "team_members": [f"{USERNAME}@test.ca"]
+                "program_curators": [USERNAME],
+                "team_members": [USERNAME]
             }
 
             response = requests.post(f"{candig_url}/ingest/program", headers=get_headers(), json=test_program)

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -42,7 +42,7 @@ def test_remove_objects(cohorts):
 
     for cohort in cohorts:
         if candig_url is not None:
-            response = requests.delete(f"{candig_url}/ingest/program/{cohort}/email/{USERNAME}@test.ca", headers=get_headers())
+            response = requests.delete(f"{candig_url}/ingest/program/{cohort}", headers=get_headers())
 
         url = f"{HOST}/ga4gh/drs/v1/cohorts/{cohort}"
         response = requests.request("GET", url, headers=headers)


### PR DESCRIPTION
Use the new authx.auth.get_site_admin_token method and clean up some of the username references to match https://github.com/CanDIG/CanDIGv2/pull/527. Of note: user2 still is used a lot in the tests, but it's fine that it's not a site admin user.