### PR TITLE
DIG-1585: if results < AGGREGATE_COUNT_THRESHOLD, censor it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 
 env:
-  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=localhost SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin INDEXING_PATH=/home/travis/build/CanDIG/tmp TESTENV_URL=http://localhost:3000
+  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=localhost SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin INDEXING_PATH=/home/travis/build/CanDIG/tmp TESTENV_URL=http://localhost:3000 AGGREGATE_COUNT_THRESHOLD=5
 
 before_install:
   - docker pull minio/minio

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - mkdir -p $INDEXING_PATH
 
 script:
+  - sed -i s@\<AGGREGATE_COUNT_THRESHOLD\>@$AGGREGATE_COUNT_THRESHOLD@ config.ini
   - python htsget_server/server.py &
   - python htsget_server/indexing.py &
   - sleep 5

--- a/config.ini
+++ b/config.ini
@@ -3,6 +3,7 @@ Port = 3000
 BasePath = /htsget/v1
 ChunkSize = 1000000
 BucketSize = 10000
+AGGREGATE_COUNT_THRESHOLD = <AGGREGATE_COUNT_THRESHOLD>
 
 [paths]
 DBPath = sqlite:///./data/files.db

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ set -Euo pipefail
 export VAULT_S3_TOKEN=$(cat /run/secrets/vault-s3-token)
 export OPA_SECRET=$(cat /run/secrets/opa-service-token)
 export VAULT_URL=$VAULT_URL
+export AGGREGATE_COUNT_THRESHOLD=$AGGREGATE_COUNT_THRESHOLD
 
 if [[ -f "initial_setup" ]]; then
     if [[ -f "/run/secrets/cert.pem" ]]; then
@@ -21,6 +22,7 @@ if [[ -f "initial_setup" ]]; then
     sed -i s@\<CANDIG_OPA_SECRET\>@$OPA_SECRET@ config.ini
     sed -i s@\<OPA_URL\>@$OPA_URL@ config.ini
     sed -i s@\<VAULT_URL\>@$VAULT_URL@ config.ini
+    sed -i s@\<AGGREGATE_COUNT_THRESHOLD\>@$AGGREGATE_COUNT_THRESHOLD@ config.ini
 
     bash create_db.sh
     mkdir $INDEXING_PATH

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -488,8 +488,7 @@ components:
       type: array
     NumTotalResults:
       description: Total number of results. NOT the number of results returned in this batch (after pagination) but the total obtained by the query.
-      minimum: 0
-      type: integer
+      type: string
     PageToken:
       description: A hash or similar that allows the server to retrieve a "page", e.g. (a subset of) a query response.
       example: ab0sc&fe1dd

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -301,6 +301,9 @@ def search(raw_req):
                 response['beaconHandovers'].append(handover)
         if len(response['beaconHandovers']) > 0 and meta['returnedGranularity'] == 'record':
             response['response'] = resultset
+            if len(resultset) > 0: # use true number if we're authorized, even if below AGGREGATE_COUNT_THRESHOLD
+                response['responseSummary']['numTotalResults'] = len(resultset)
+
         else:
             response.pop('beaconHandovers')
             if meta['returnedGranularity'] == 'boolean':

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -9,6 +9,7 @@ import re
 import connexion
 from functools import reduce
 import authz
+from config import AGGREGATE_COUNT_THRESHOLD
 
 
 app = Flask(__name__)
@@ -272,7 +273,10 @@ def search(raw_req):
 
 
         if len(resultset) > 0:
-            response['responseSummary']['numTotalResults'] = len(resultset)
+            if len(resultset) < int(AGGREGATE_COUNT_THRESHOLD):
+                response['responseSummary']['numTotalResults'] = f"<{AGGREGATE_COUNT_THRESHOLD}"
+            else:
+                response['responseSummary']['numTotalResults'] = len(resultset)
             response['responseSummary']['exists'] = True
 
         # if the request granularity was "record", check to see that the user is actually authorized to see any cohorts:

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -27,6 +27,8 @@ BUCKET_SIZE = int(config['DEFAULT']['BucketSize'])
 
 PORT = config['DEFAULT']['Port']
 
+AGGREGATE_COUNT_THRESHOLD = config['DEFAULT']['AGGREGATE_COUNT_THRESHOLD']
+
 TEST_KEY = os.getenv("HTSGET_TEST_KEY", "testtesttest")
 
 USE_MINIO_SANDBOX = False


### PR DESCRIPTION
To test:
```
curl "http://candig.docker.internal:5080/genomics/beacon/v2/g_variants?geneId=SLC2A5" \
     -H 'Authorization: Bearer <user1 token>'
```
That should return 
```
"responseSummary": {
    "exists": true,
    "numTotalResults": "<5"
  }
```
but if you use user2's token, you'll get the full results, including 
```
  "responseSummary": {
    "exists": true,
    "numTotalResults": 2
  }
```
