### PR TITLE
Allow Query to access cohort samples without authorization

### DIFF
--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -15,7 +15,7 @@ def is_testing(request):
         return True
 
 
-def is_authed(id_, request):
+def is_authed(id_, request, allow_elevated_privileges=False):
     if request is None:
         return 401
     if is_testing(request):
@@ -24,7 +24,7 @@ def is_authed(id_, request):
         obj = database.get_drs_object(id_)
         if obj is not None and 'cohort' in obj:
             if is_cohort_authorized(request, obj['cohort']) \
-                or request_is_from_query(request):
+                or (allow_elevated_privileges and request_is_from_query(request)):
                 return 200
         else:
             return 404

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -23,7 +23,8 @@ def is_authed(id_, request):
     if "Authorization" in request.headers:
         obj = database.get_drs_object(id_)
         if obj is not None and 'cohort' in obj:
-            if is_cohort_authorized(request, obj['cohort']):
+            if is_cohort_authorized(request, obj['cohort']) \
+                or request_is_from_query(request):
                 return 200
         else:
             return 404

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -15,7 +15,7 @@ def is_testing(request):
         return True
 
 
-def is_authed(id_, request, allow_elevated_privileges=False):
+def is_authed(id_, request):
     if request is None:
         return 401
     if is_testing(request):
@@ -24,7 +24,7 @@ def is_authed(id_, request, allow_elevated_privileges=False):
         obj = database.get_drs_object(id_)
         if obj is not None and 'cohort' in obj:
             if is_cohort_authorized(request, obj['cohort']) \
-                or (allow_elevated_privileges and request_is_from_query(request)):
+                or request_is_from_query(request):
                 return 200
         else:
             return 404

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -34,7 +34,7 @@ def get_service_info():
 
 
 @app.route('/ga4gh/drs/v1/objects/<path:object_id>')
-def get_object(object_id, expand=False):
+def get_object(object_id, expand=False, allow_elevated_privileges=False):
     app.logger.debug(f"looking for object {object_id}")
     access_url_parse = re.match(r"(.+?)/access_url/(.+)", escape(object_id))
     if access_url_parse is not None:
@@ -42,7 +42,7 @@ def get_object(object_id, expand=False):
     new_object = None
     if object_id is not None:
         new_object = database.get_drs_object(escape(object_id), expand)
-        auth_code = authz.is_authed(escape(object_id), request)
+        auth_code = authz.is_authed(escape(object_id), request, allow_elevated_privileges)
         if auth_code != 200:
             return {"message": f"Not authorized to access object {object_id}"}, auth_code
     if new_object is None:

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -34,7 +34,7 @@ def get_service_info():
 
 
 @app.route('/ga4gh/drs/v1/objects/<path:object_id>')
-def get_object(object_id, expand=False, allow_elevated_privileges=False):
+def get_object(object_id, expand=False):
     app.logger.debug(f"looking for object {object_id}")
     access_url_parse = re.match(r"(.+?)/access_url/(.+)", escape(object_id))
     if access_url_parse is not None:
@@ -42,7 +42,7 @@ def get_object(object_id, expand=False, allow_elevated_privileges=False):
     new_object = None
     if object_id is not None:
         new_object = database.get_drs_object(escape(object_id), expand)
-        auth_code = authz.is_authed(escape(object_id), request, allow_elevated_privileges)
+        auth_code = authz.is_authed(escape(object_id), request)
         if auth_code != 200:
             return {"message": f"Not authorized to access object {object_id}"}, auth_code
     if new_object is None:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -234,7 +234,7 @@ def get_matching_transcripts(id_=None):
 
 
 @app.route('/samples/<path:id_>')
-def get_sample(id_=None):
+def get_sample(id_=None, allow_elevated_privileges=False):
     result = {
         "sample_id": id_,
         "genomes": [],
@@ -245,7 +245,7 @@ def get_sample(id_=None):
 
     # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
     # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
-    sample_drs_obj, result_code = drs_operations.get_object(id_)
+    sample_drs_obj, result_code = drs_operations.get_object(id_, allow_elevated_privileges=allow_elevated_privileges)
     if result_code == 200 and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
         result["cohort"] = sample_drs_obj["cohort"]
         for contents_obj in sample_drs_obj["contents"]:
@@ -284,7 +284,7 @@ def get_cohort_samples(cohort=None):
     samples = list(map(lambda y: y["id"], filter(lambda x: x["description"] == "sample", sample_drs_objs)))
     result = []
     for sample in samples:
-        res, status_code = get_sample(sample)
+        res, status_code = get_sample(sample, allow_elevated_privileges=True)
         if status_code == 200:
             result.append(res)
     return result, 200

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -245,8 +245,8 @@ def get_sample(id_=None):
 
     # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
     # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
-    sample_drs_obj, result_code = drs_operations.get_object(id_)
-    if result_code == 200 and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
+    sample_drs_obj = database.get_drs_object(id_)
+    if sample_drs_obj is not None and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
         result["cohort"] = sample_drs_obj["cohort"]
         for contents_obj in sample_drs_obj["contents"]:
             drs_obj = database.get_drs_object(contents_obj["id"])
@@ -262,7 +262,8 @@ def get_sample(id_=None):
                             result["variants"].append(drs_obj["id"])
                         elif content["id"] == "read":
                             result["reads"].append(drs_obj["id"])
-        return result, 200
+        if authz.is_authed(id_, request):
+            return result, 200
     return {"message": f"Could not find sample {id_}"}, 404
 
 

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -234,7 +234,7 @@ def get_matching_transcripts(id_=None):
 
 
 @app.route('/samples/<path:id_>')
-def get_sample(id_=None, allow_elevated_privileges=False):
+def get_sample(id_=None):
     result = {
         "sample_id": id_,
         "genomes": [],
@@ -245,7 +245,7 @@ def get_sample(id_=None, allow_elevated_privileges=False):
 
     # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
     # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
-    sample_drs_obj, result_code = drs_operations.get_object(id_, allow_elevated_privileges=allow_elevated_privileges)
+    sample_drs_obj, result_code = drs_operations.get_object(id_)
     if result_code == 200 and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
         result["cohort"] = sample_drs_obj["cohort"]
         for contents_obj in sample_drs_obj["contents"]:
@@ -284,7 +284,7 @@ def get_cohort_samples(cohort=None):
     samples = list(map(lambda y: y["id"], filter(lambda x: x["description"] == "sample", sample_drs_objs)))
     result = []
     for sample in samples:
-        res, status_code = get_sample(sample, allow_elevated_privileges=True)
+        res, status_code = get_sample(sample)
         if status_code == 200:
             result.append(res)
     return result, 200


### PR DESCRIPTION
# Description

[Jira ticket](https://candig.atlassian.net/browse/DIG-1626)

Query currently can't get genomic completeness stats without the signed-in user having authorization to all cohorts. This will allow queries specifically from Query to access exactly one endpoint with elevated privileges -- `/htsget/v1/samples`.

NB: I'm not entirely certain this is the best way to have gone about this -- welcoming any ideas for how this could be cleaner.

## To Test

- Build with the integration test data
```
(candig) 10:39 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ curl candig.docker.internal:5080/query/genomic_completeness -H "Authorization: Bearer <User 2 token>"
```
Returns
```
{
  "SYNTHETIC-1": {
    "all": 0,
    "genomes": 2,
    "transcriptomes": 0
  },
  "SYNTHETIC-2": {
    "all": 0,
    "genomes": 2,
    "transcriptomes": 0
  }
}
```
with this PR. WIthout it, SYNTHETIC-1 will be missing.