### PR TITLE
Removing minio from the stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,9 @@ services:
   - docker
 
 env:
-  - MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin MINIO_URL=http://localhost:9000 MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin HTSGET_TEST_KEY=thisisatest USE_MINIO_SANDBOX=True DB_PATH=localhost SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin INDEXING_PATH=/home/travis/build/CanDIG/tmp TESTENV_URL=http://localhost:3000 AGGREGATE_COUNT_THRESHOLD=5
+  - HTSGET_TEST_KEY=thisisatest DB_PATH=localhost SERVER_LOCAL_DATA=/home/travis/build/CanDIG/htsget_app/data PGPASSWORD=OG0pjmnQDWUTvLotYrxPrg PGUSER=admin INDEXING_PATH=/home/travis/build/CanDIG/tmp TESTENV_URL=http://localhost:3000 AGGREGATE_COUNT_THRESHOLD=5
 
 before_install:
-  - docker pull minio/minio
-  - docker create -p9090:9090 -p9000:9000 -p9001:9001 minio/minio minio server /data | xargs -I{} docker start {}
   - docker pull postgres:15-alpine
   - docker create -p5433:5432 -p5432:5432 --env POSTGRES_USER=admin --env POSTGRES_DB=metadata --env POSTGRES_PASSWORD=OG0pjmnQDWUTvLotYrxPrg --env POSTGRES_HOST_AUTH_METHOD=password --name metadata-db postgres:15-alpine | xargs -I{} docker start {}
   - docker ps -a


### PR DESCRIPTION
We don't need to load minio anymore, since we've taken it out of the tests.