### PR TITLE
DIG-1664: Do not log service-info calls (prevent health check flooding)

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -10,3 +10,5 @@ gid = candig
 uid = candig
 
 harakiri = 60
+
+route = /service-info donotlog:


### PR DESCRIPTION
**Requires the `bugfix/silence-service-info` branch from the main CanDIGv2 repo, in order to fix the health check.**

Suppress logging for the /service-info endpoint, to prevent the logs from getting flooded.

To test: Check that the logs are no longer filled every half minute.