### PR TITLE
Replace 'single quote' in PR titles

### DIFF
--- a/.github/workflows/candig-dispatch.yml
+++ b/.github/workflows/candig-dispatch.yml
@@ -1,9 +1,9 @@
 ---
 name: Submodule PR
 on:
-  push:
-    branches:
-      - develop
+  pull_request:
+        branches: [develop]
+        types: [closed]
 jobs:
   CanDIG-dispatch:
     runs-on: ubuntu-latest
@@ -12,21 +12,23 @@ jobs:
       CHECKOUT_BRANCH: develop
       PR_AGAINST_BRANCH: develop
       OWNER: CanDIG
+    if: github.event.pull_request.merged == true
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: get PR data
-        uses: actions/github-script@v7
-        id: get_pr_data
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
+        shell: python
+        run: |
+            import json
+            import os
+            with open('${{ github.event_path }}') as fh:
+                event = json.load(fh)
+                escaped = event['pull_request']['title'].replace("'", '"')
+                pr_number = event["number"]
+                print(escaped)    
+            with open(os.environ['GITHUB_ENV'], 'a') as fh:
+                print(f'PR_TITLE={escaped}', file=fh)
+                print(f'PR_NUMBER={pr_number}', file=fh)
       - name: Create PR in CanDIGv2
         id: make_pr
         uses: CanDIG/github-action-pr-expanded@v4
@@ -35,7 +37,7 @@ jobs:
           parent_repository: ${{ env.PARENT_REPOSITORY }}
           checkout_branch: ${{ env.CHECKOUT_BRANCH}}
           pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
-          pr_title: "${{ github.repository }} merging: ${{ fromJson(steps.get_pr_data.outputs.result).title }}"
-          pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`. PR link:[#${{ fromJson(steps.get_pr_data.outputs.result).number }}](https://github.com/${{ github.repository }}/pull/${{ fromJson(steps.get_pr_data.outputs.result).number }})"
+          pr_title: "${{ github.repository }} merging: ${{ env.PR_TITLE }}"
+          pr_description: "PR triggered by update to develop branch on ${{ github.repository }}. Commit hash: `${{ github.sha }}`. PR link: [#${{ env.PR_NUMBER }}](https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }})"
           owner: ${{ env.OWNER }}
           submodule_path: lib/htsget/htsget_app


### PR DESCRIPTION
- Updating the dispatch action to allow PR titles with single quotes
  - replaces single quotes with double quotes in PR title
- Change to using python to get the PR title and number and saves as env variables
- Slight change to when it is being triggered, triggered by the merged pull request instead of the push to develop

This was needed because single quotes were causing the the dispatch action to fail as they are interpreted as a variable instead of just a string