### PR TITLE
DIG-1660: Clean up variantfile when deleting drs objects

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -424,7 +424,7 @@ def create_drs_object(obj):
         if len(new_object.access_methods) != 0:
             for method in new_object.access_methods:
                 session.delete(method)
-            session.commit()
+                session.commit()
         for method in obj['access_methods']:
             new_method = AccessMethod()
             new_method.drs_object_id = new_object.id
@@ -445,6 +445,7 @@ def create_drs_object(obj):
         if len(new_object.contents) != 0:
             for contents in new_object.contents:
                 session.delete(contents)
+                session.commit()
         for contents in obj['contents']:
             new_contents = ContentsObject()
             new_contents.drs_object_id = new_object.id
@@ -476,6 +477,7 @@ def delete_drs_object(obj_id):
             variantfiles = session.query(VariantFile).filter_by(drs_object_id=new_object.id).all()
             for vf in variantfiles:
                 session.delete(vf)
+                session.commit()
         session.delete(new_object)
         session.commit()
         return json.loads(str(new_object))
@@ -523,7 +525,9 @@ def delete_cohort(cohort_id):
         for cohort_obj in cohort_objs:
             for drs_obj in cohort_obj.associated_drs:
                 session.delete(drs_obj)
+                session.commit()
             session.delete(cohort_obj)
+            session.commit()
         session.commit()
         return json.loads(str(cohort_objs))
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -273,7 +273,7 @@ class DrsObject(ObjectDBBase):
     contents = relationship("ContentsObject", cascade="all, delete, delete-orphan")
     cohort_id = Column(String, ForeignKey('cohort.id'))
     cohort = relationship("Cohort", back_populates="associated_drs")
-    variantfile = relationship("VariantFile", back_populates="drs_object")
+    variantfile = relationship("VariantFile", back_populates="drs_object", cascade="all, delete")
 
     def __repr__(self):
         result = {


### PR DESCRIPTION
Make sure that variantfile is cascade deleted when its parent drs_object is deleted. Also cleaned up a lot of stale data after deletion: I made sure that every session.delete was followed by a session.commit.

Marion: you should now be able to cleanly add and delete genomic files as you described in https://candig.atlassian.net/browse/DIG-1660.