### PR TITLE
DIG-1650: Handle exceptions more gracefully

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -41,4 +41,5 @@ fi
 # run any migrations:
 echo "running migrations..."
 psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_288.sql >>setup_out.txt
+psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_315.sql >>setup_out.txt
 echo "...done"

--- a/create_db.sh
+++ b/create_db.sh
@@ -32,8 +32,7 @@ if [[ $numgenes -lt 5 ]]; then
     echo "adding data to ncbirefseq..."
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg37\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg37.txt >> genes.sql
     awk '{ print "INSERT INTO ncbirefseq (reference_genome, transcript_name, contig, start, endpos, gene_name) VALUES (" "\047hg38\047, \047" $1 "\047, \047" $2 "\047, " $3 ", " $4 ", \047" $5 "\047) ON CONFLICT DO NOTHING;"}' data/refseq/ncbiRefSeqSelect.hg38.txt >> genes.sql
-
-    psql --quiet -h "$db" -U $PGUSER -d genomic -a -f genes.sql >>setup_out.txt
+    psql --quiet -h "$db" -U $PGUSER -d genomic -a -c 'SET synchronous_commit TO off;' -c '\i genes.sql' -c 'SET synchronous_commit TO on;' >> setup_out.txt
     # rm genes.sql
     echo "...done"
 fi

--- a/data/files.sql
+++ b/data/files.sql
@@ -7,7 +7,7 @@ CREATE TABLE drs_object (
         id VARCHAR NOT NULL,
         name VARCHAR,
         self_uri VARCHAR,
-        size INTEGER,
+        size BIGINT,
         created_time VARCHAR,
         updated_time VARCHAR,
         version VARCHAR,

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -2,7 +2,6 @@ from flask import Flask
 import variants
 import drs_operations
 import htsget_operations
-import variants
 import database
 import json
 import re

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -197,26 +197,32 @@ def search(raw_req):
     if 'end' in req and len(req['end']) > 0:
         actual_params['end'] = req['end'].pop(0)
     if 'gene_id' in req:
-        genes = database.search_refseqs(req['gene_id'].upper(), 'gene_name')
-        if len(genes) > 0:
-            for gene in genes:
-                if gene['reference_genome'] == actual_params['reference_genome']:
-                    actual_params['reference_name'] = database.normalize_contig(gene['contig'])
-                    if actual_params['reference_name'] is not None:
-                        actual_params['start'] = gene['start']
-                        actual_params['end'] = gene['end']
-                        break
-        else:
-            response = {
-                    'error': {
-                        'errorMessage': f"no region was found for geneId {req['gene_id']}",
-                        'errorCode': 404
-                    },
-                    'meta': meta
-                }
-            return response
+        try:
+            genes = database.search_refseqs(req['gene_id'].upper(), 'gene_name')
+            if len(genes) > 0:
+                for gene in genes:
+                    if gene['reference_genome'] == actual_params['reference_genome']:
+                        actual_params['reference_name'] = database.normalize_contig(gene['contig'])
+                        if actual_params['reference_name'] is not None:
+                            actual_params['start'] = gene['start']
+                            actual_params['end'] = gene['end']
+                            break
+            else:
+                response = {
+                        'error': {
+                            'errorMessage': f"no region was found for geneId {req['gene_id']}",
+                            'errorCode': 404
+                        },
+                        'meta': meta
+                    }
+                return response
+        except Exception as e:
+            raise Exception(f"exception finding refseq for {req['gene_id']}: {type(e)} {str(e)}")
     if 'genomic_allele_short_form' in req:
-        allele_loc = variants.convert_hgvsid_to_location(req['genomic_allele_short_form'], reference_genome=actual_params['reference_genome'])
+        try:
+            allele_loc = variants.convert_hgvsid_to_location(req['genomic_allele_short_form'], reference_genome=actual_params['reference_genome'])
+        except Exception as e:
+            raise Exception(f"exception in convert_hgvsid_to_location for {req['genomic_allele_short_form']}: {type(e)} {str(e)}")
         if allele_loc is not None:
             actual_params['reference_name'] = allele_loc['reference_name']
             actual_params['start'] = allele_loc['start']
@@ -233,10 +239,14 @@ def search(raw_req):
         # if there is no end specified, assume the end is same as start:
         if 'end' not in actual_params:
             actual_params['end'] = actual_params['start']
-
-        variants_by_file = variants.find_variants_in_region(reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
-
-        resultset = compile_beacon_resultset(variants_by_file, reference_genome=actual_params['reference_genome'])
+        try:
+            variants_by_file = variants.find_variants_in_region(reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+        except Exception as e:
+            raise Exception(f"exception in find_variants_in_region for {actual_params}: {type(e)} {str(e)}")
+        try:
+            resultset = compile_beacon_resultset(variants_by_file, reference_genome=actual_params['reference_genome'])
+        except Exception as e:
+            raise Exception(f"exception in compile_beacon_resultset for {actual_params}: {type(e)} {str(e)}")
         # others are for filtering after:
         #         aminoacidChange: string,
         #         alternate_bases: string,
@@ -294,7 +304,10 @@ def search(raw_req):
                             query_info[drs_obj["cohort"]].append(c["name"])
 
             # fill in handover data
-            handover, status_code = htsget_operations.get_variants(id_=drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+            try:
+                handover, status_code = htsget_operations.get_variants(id_=drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+            except Exception as e:
+                raise Exception(f"exception in get_variants for {drs_obj_id}: {type(e)} {str(e)}")
             if handover is not None:
                 handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
                 response['beaconHandovers'].append(handover)

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -449,6 +449,7 @@ def compile_beacon_resultset(variants_by_obj, reference_genome="hg38"):
         if 'caseLevelData' in resultset[variant] and len(resultset[variant]['caseLevelData']) > 0:
             resultset[variant]['variantInternalId'] = variant
             final_resultset.append(resultset[variant])
+    final_resultset.sort(key=lambda x: x['variantInternalId'])
     return final_resultset
 
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -424,7 +424,7 @@ def create_drs_object(obj):
         if len(new_object.access_methods) != 0:
             for method in new_object.access_methods:
                 session.delete(method)
-            session.commit()
+                session.commit()
         for method in obj['access_methods']:
             new_method = AccessMethod()
             new_method.drs_object_id = new_object.id
@@ -445,6 +445,7 @@ def create_drs_object(obj):
         if len(new_object.contents) != 0:
             for contents in new_object.contents:
                 session.delete(contents)
+                session.commit()
         for contents in obj['contents']:
             new_contents = ContentsObject()
             new_contents.drs_object_id = new_object.id
@@ -476,6 +477,7 @@ def delete_drs_object(obj_id):
             variantfiles = session.query(VariantFile).filter_by(drs_object_id=new_object.id).all()
             for vf in variantfiles:
                 session.delete(vf)
+                session.commit()
         session.delete(new_object)
         session.commit()
         return json.loads(str(new_object))
@@ -523,7 +525,9 @@ def delete_cohort(cohort_id):
         for cohort_obj in cohort_objs:
             for drs_obj in cohort_obj.associated_drs:
                 session.delete(drs_obj)
+                session.commit()
             session.delete(cohort_obj)
+            session.commit()
         session.commit()
         return json.loads(str(cohort_objs))
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -273,7 +273,7 @@ class DrsObject(ObjectDBBase):
     contents = relationship("ContentsObject", cascade="all, delete, delete-orphan")
     cohort_id = Column(String, ForeignKey('cohort.id'))
     cohort = relationship("Cohort", back_populates="associated_drs")
-    variantfile = relationship("VariantFile", back_populates="drs_object")
+    variantfile = relationship("VariantFile", back_populates="drs_object", cascade="all, delete")
 
     def __repr__(self):
         result = {

--- a/htsget_server/server.py
+++ b/htsget_server/server.py
@@ -22,5 +22,4 @@ def index():
     return 'INDEX'
 
 if __name__ == '__main__':
-    logging.basicConfig(filename='record.log', level=logging.DEBUG, format=f'%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s')
     app.run(port = PORT, debug=DEBUG_MODE)

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -472,7 +472,7 @@ def get_beacon_post_search():
     return [
         (
             # 6 variations, corresponding to three variant records in multisample_1 and multisample_2
-            # first variation, corresponding to "NC_000021.9:g.5030847=", should contain two cases
+            # first variation, corresponding to "NC_000021.9:g.5030551=", should contain two cases
             {
                 "query": {
                     "requestParameters": {


### PR DESCRIPTION
(picks up #314, so may need rebase before merge)

* Report a lot of exceptions at a more granular level
* For commonly-used database operations (get/create drs objects, create variantfile), try three times in case of db lock before giving up
* Beacon resultsets should be sorted so that they have a consistent sort order on output
* Drs object file sizes need to be bigints in the database
* Speed up inserting ncbirefseqs on db initialization (goes from 50 seconds on my local stack to 15 seconds)

Really, there's no good way to test this except that integration tests should succeed consistently.