### PR TITLE
DIG-1719: switch to candigv2-logging module

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,9 @@ if [[ -f "initial_setup" ]]; then
     rm initial_setup
 fi
 
+python -c "import candigv2_logging.logging
+candigv2_logging.logging.initialize()"
+
 # use the following for development
 #python3 htsget_server/server.py
 

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -3,6 +3,7 @@ from config import AUTHZ, TEST_KEY
 from flask import Flask
 import database
 import authx.auth
+from candigv2_logging.logging import log_message
 
 
 app = Flask(__name__)
@@ -10,8 +11,7 @@ app = Flask(__name__)
 
 def is_testing(request):
     if request.headers.get("Authorization") == f"Bearer {TEST_KEY}":
-        print("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
-        app.logger.warning("WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
+        log_message("WARNING","WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         return True
 
 
@@ -39,8 +39,7 @@ def get_authorized_cohorts(request):
     try:
         return authx.auth.get_opa_datasets(request)
     except Exception as e:
-        print(f"Couldn't authorize cohorts: {type(e)} {str(e)}")
-        app.logger.warning(f"Couldn't authorize cohorts: {type(e)} {str(e)}")
+        log_message("WARNING",f"Couldn't authorize cohorts: {type(e)} {str(e)}")
         return []
 
 
@@ -60,8 +59,7 @@ def is_site_admin(request):
         try:
             return authx.auth.is_site_admin(request)
         except Exception as e:
-            print(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
-            app.logger.warning(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
+            log_message("WARNING",f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             return False
     return False
 

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -3,7 +3,10 @@ from config import AUTHZ, TEST_KEY
 from flask import Flask
 import database
 import authx.auth
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 app = Flask(__name__)
@@ -11,7 +14,7 @@ app = Flask(__name__)
 
 def is_testing(request):
     if request.headers.get("Authorization") == f"Bearer {TEST_KEY}":
-        log_message("WARNING","WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
+        logger.log_message("WARNING","WARNING: TEST MODE, AUTHORIZATION IS DISABLED")
         return True
 
 
@@ -39,7 +42,7 @@ def get_authorized_cohorts(request):
     try:
         return authx.auth.get_opa_datasets(request)
     except Exception as e:
-        log_message("WARNING",f"Couldn't authorize cohorts: {type(e)} {str(e)}")
+        logger.log_message("WARNING",f"Couldn't authorize cohorts: {type(e)} {str(e)}")
         return []
 
 
@@ -59,7 +62,7 @@ def is_site_admin(request):
         try:
             return authx.auth.is_site_admin(request)
         except Exception as e:
-            log_message("WARNING",f"Couldn't authorize site_admin: {type(e)} {str(e)}")
+            logger.log_message("WARNING",f"Couldn't authorize site_admin: {type(e)} {str(e)}")
             return False
     return False
 

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -9,6 +9,7 @@ import connexion
 from functools import reduce
 import authz
 from config import AGGREGATE_COUNT_THRESHOLD
+from candigv2_logging.logging import log_message
 
 
 app = Flask(__name__)

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -9,7 +9,10 @@ import connexion
 from functools import reduce
 import authz
 from config import AGGREGATE_COUNT_THRESHOLD
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 app = Flask(__name__)

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -1,9 +1,12 @@
 import configparser
 import os
 import re
+import logging
 
 config = configparser.ConfigParser(interpolation=None)
 config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../config.ini"))
+
+logging.basicConfig(level=logging.INFO, format=f'%(asctime)s {os.getenv("SERVICE_NAME")} %(name)s %(levelname)s : %(message)s')
 
 AUTHZ = config['authz']
 HTSGET_URL = os.getenv("HTSGET_URL", f"http://localhost:{config['DEFAULT']['Port']}")

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -1,12 +1,9 @@
 import configparser
 import os
 import re
-import logging
 
 config = configparser.ConfigParser(interpolation=None)
 config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../config.ini"))
-
-logging.basicConfig(level=logging.INFO, format=f'%(asctime)s {os.getenv("SERVICE_NAME")} %(name)s %(levelname)s : %(message)s')
 
 AUTHZ = config['authz']
 HTSGET_URL = os.getenv("HTSGET_URL", f"http://localhost:{config['DEFAULT']['Port']}")
@@ -21,7 +18,6 @@ else:
 
 DB_PATH = re.sub("PASSWORD", password, config['paths']['PGPath'])
 DB_PATH = re.sub("HOST", os.environ.get("DB_PATH"), DB_PATH)
-print(f"Password is: {password}")
 
 CHUNK_SIZE = int(config['DEFAULT']['ChunkSize'])
 

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -1,7 +1,6 @@
 import configparser
 import os
 import re
-from minio import Minio
 
 config = configparser.ConfigParser(interpolation=None)
 config.read(os.path.abspath(f"{os.path.dirname(os.path.realpath(__file__))}/../config.ini"))
@@ -30,12 +29,6 @@ PORT = config['DEFAULT']['Port']
 AGGREGATE_COUNT_THRESHOLD = config['DEFAULT']['AGGREGATE_COUNT_THRESHOLD']
 
 TEST_KEY = os.getenv("HTSGET_TEST_KEY", "testtesttest")
-
-USE_MINIO_SANDBOX = False
-if os.environ.get("USE_MINIO_SANDBOX") == "True":
-    USE_MINIO_SANDBOX = True
-
-VAULT_S3_TOKEN = os.getenv("VAULT_S3_TOKEN", "none")
 
 DEBUG_MODE = False
 if os.getenv("DEBUG_MODE", "1") == "1":

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -9,7 +9,8 @@ from config import DB_PATH, BUCKET_SIZE, HTSGET_URL
 from flask import Flask
 import logging
 
-app = Flask(__name__)
+
+logger = logging.getLogger(__file__)
 
 engine = create_engine(DB_PATH, echo=False)
 
@@ -375,7 +376,7 @@ def get_drs_object(object_id, expand=False, tries=1):
     #             expand doesn't do anything on this DRS server
                 return new_obj
         except Exception as e:
-            app.logger.info(f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
+            logger.debug(f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
             return get_drs_object(object_id, expand, tries=tries+1)
         return None
 
@@ -598,7 +599,7 @@ def get_variantfile(variantfile_id, tries=1):
                 new_obj = json.loads(str(result))
                 return new_obj
         except Exception as e:
-            app.logger.info(f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
+            logger.debug(f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
             return get_variantfile(variantfile_id, tries=tries+1)
         return None
 
@@ -941,6 +942,6 @@ def search(obj, tries=1):
                 results.append(curr_result)
             return results
         except Exception as e:
-            app.logger.info(f"Exception in search: {str(e)}, trying again")
+            logger.debug(f"Exception in search: {str(e)}, trying again")
             return search(obj, tries=tries+1)
     return None

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -10,7 +10,6 @@ from flask import Flask
 import logging
 
 app = Flask(__name__)
-logging.basicConfig(level=logging.INFO, format=f'%(threadName)s %(asctime)s %(levelname)s %(name)s : %(message)s')
 
 engine = create_engine(DB_PATH, echo=False)
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -7,10 +7,8 @@ from random import randint
 from time import sleep
 from config import DB_PATH, BUCKET_SIZE, HTSGET_URL
 from flask import Flask
-import logging
+from candigv2_logging.logging import log_message
 
-
-logger = logging.getLogger(__file__)
 
 engine = create_engine(DB_PATH, echo=False)
 
@@ -376,7 +374,7 @@ def get_drs_object(object_id, expand=False, tries=1):
     #             expand doesn't do anything on this DRS server
                 return new_obj
         except Exception as e:
-            logger.debug(f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
+            log_message("DEBUG",f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
             return get_drs_object(object_id, expand, tries=tries+1)
         return None
 
@@ -599,7 +597,7 @@ def get_variantfile(variantfile_id, tries=1):
                 new_obj = json.loads(str(result))
                 return new_obj
         except Exception as e:
-            logger.debug(f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
+            log_message("DEBUG",f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
             return get_variantfile(variantfile_id, tries=tries+1)
         return None
 
@@ -942,6 +940,6 @@ def search(obj, tries=1):
                 results.append(curr_result)
             return results
         except Exception as e:
-            logger.debug(f"Exception in search: {str(e)}, trying again")
+            log_message("DEBUG",f"Exception in search: {str(e)}, trying again")
             return search(obj, tries=tries+1)
     return None

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -7,7 +7,10 @@ from random import randint
 from time import sleep
 from config import DB_PATH, BUCKET_SIZE, HTSGET_URL
 from flask import Flask
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 engine = create_engine(DB_PATH, echo=False)
@@ -374,7 +377,7 @@ def get_drs_object(object_id, expand=False, tries=1):
     #             expand doesn't do anything on this DRS server
                 return new_obj
         except Exception as e:
-            log_message("DEBUG",f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
+            logger.log_message("DEBUG",f"Exception in get_drs_object {object_id}: {str(e)}, trying again")
             return get_drs_object(object_id, expand, tries=tries+1)
         return None
 
@@ -597,7 +600,7 @@ def get_variantfile(variantfile_id, tries=1):
                 new_obj = json.loads(str(result))
                 return new_obj
         except Exception as e:
-            log_message("DEBUG",f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
+            logger.log_message("DEBUG",f"Exception in get_variantfile {variantfile_id}: {str(e)}, trying again")
             return get_variantfile(variantfile_id, tries=tries+1)
         return None
 
@@ -940,6 +943,6 @@ def search(obj, tries=1):
                 results.append(curr_result)
             return results
         except Exception as e:
-            log_message("DEBUG",f"Exception in search: {str(e)}, trying again")
+            logger.log_message("DEBUG",f"Exception in search: {str(e)}, trying again")
             return search(obj, tries=tries+1)
     return None

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -11,7 +11,10 @@ from urllib.parse import parse_qs, urlparse, urlencode
 from config import INDEXING_PATH
 from time import sleep
 from random import randint
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 app = Flask(__name__)
@@ -38,7 +41,7 @@ def get_service_info():
 
 @app.route('/ga4gh/drs/v1/objects/<path:object_id>')
 def get_object(object_id, expand=False):
-    log_message("DEBUG",f"looking for object {object_id}")
+    logger.log_message("DEBUG",f"looking for object {object_id}")
     access_url_parse = re.match(r"(.+?)/access_url/(.+)", escape(object_id))
     if access_url_parse is not None:
         return get_access_url(access_url_parse.group(1), access_url_parse.group(2))
@@ -88,7 +91,7 @@ def post_object(tries=1):
     try:
         new_object = database.create_drs_object(connexion.request.json)
     except Exception as e:
-        log_message("DEBUG",f"Exception in post_object {object_id}: {str(e)}, trying again")
+        logger.log_message("DEBUG",f"Exception in post_object {object_id}: {str(e)}, trying again")
         return post_object(tries=tries+1)
     return new_object, 200
 
@@ -303,7 +306,7 @@ def _get_file_path(drs_file_obj_id):
 
 
 def _get_access_url(access_id):
-    log_message("DEBUG",f"looking for url {access_id}")
+    logger.log_message("DEBUG",f"looking for url {access_id}")
     id_parse = re.match(r"((https*:\/\/)*.+?)\/(.+?)\/(.+?)(\?(.+))*$", access_id)
     if id_parse is not None:
         endpoint = id_parse.group(1)

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -11,7 +11,10 @@ from urllib.parse import parse_qs, urlparse, urlencode
 from config import INDEXING_PATH
 from time import sleep
 from random import randint
+import logging
 
+
+logger = logging.getLogger(__file__)
 
 app = Flask(__name__)
 
@@ -37,7 +40,7 @@ def get_service_info():
 
 @app.route('/ga4gh/drs/v1/objects/<path:object_id>')
 def get_object(object_id, expand=False):
-    app.logger.debug(f"looking for object {object_id}")
+    logger.debug(f"looking for object {object_id}")
     access_url_parse = re.match(r"(.+?)/access_url/(.+)", escape(object_id))
     if access_url_parse is not None:
         return get_access_url(access_url_parse.group(1), access_url_parse.group(2))
@@ -87,7 +90,7 @@ def post_object(tries=1):
     try:
         new_object = database.create_drs_object(connexion.request.json)
     except Exception as e:
-        app.logger.info(f"Exception in post_object {object_id}: {str(e)}, trying again")
+        logger.debug(f"Exception in post_object {object_id}: {str(e)}, trying again")
         return post_object(tries=tries+1)
     return new_object, 200
 
@@ -302,7 +305,7 @@ def _get_file_path(drs_file_obj_id):
 
 
 def _get_access_url(access_id):
-    app.logger.debug(f"looking for url {access_id}")
+    logger.debug(f"looking for url {access_id}")
     id_parse = re.match(r"((https*:\/\/)*.+?)\/(.+?)\/(.+?)(\?(.+))*$", access_id)
     if id_parse is not None:
         endpoint = id_parse.group(1)

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -11,10 +11,8 @@ from urllib.parse import parse_qs, urlparse, urlencode
 from config import INDEXING_PATH
 from time import sleep
 from random import randint
-import logging
+from candigv2_logging.logging import log_message
 
-
-logger = logging.getLogger(__file__)
 
 app = Flask(__name__)
 
@@ -40,7 +38,7 @@ def get_service_info():
 
 @app.route('/ga4gh/drs/v1/objects/<path:object_id>')
 def get_object(object_id, expand=False):
-    logger.debug(f"looking for object {object_id}")
+    log_message("DEBUG",f"looking for object {object_id}")
     access_url_parse = re.match(r"(.+?)/access_url/(.+)", escape(object_id))
     if access_url_parse is not None:
         return get_access_url(access_url_parse.group(1), access_url_parse.group(2))
@@ -90,7 +88,7 @@ def post_object(tries=1):
     try:
         new_object = database.create_drs_object(connexion.request.json)
     except Exception as e:
-        logger.debug(f"Exception in post_object {object_id}: {str(e)}, trying again")
+        log_message("DEBUG",f"Exception in post_object {object_id}: {str(e)}, trying again")
         return post_object(tries=tries+1)
     return new_object, 200
 
@@ -305,7 +303,7 @@ def _get_file_path(drs_file_obj_id):
 
 
 def _get_access_url(access_id):
-    logger.debug(f"looking for url {access_id}")
+    log_message("DEBUG",f"looking for url {access_id}")
     id_parse = re.match(r"((https*:\/\/)*.+?)\/(.+?)\/(.+?)(\?(.+))*$", access_id)
     if id_parse is not None:
         endpoint = id_parse.group(1)

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -11,7 +11,10 @@ import connexion
 import variants
 import indexing
 from pathlib import Path
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 app = Flask(__name__)
@@ -122,7 +125,7 @@ def get_variants(id_=None, reference_name=None, start=None, end=None, class_=Non
     if id_ is not None:
         auth_code = authz.is_authed(escape(id_), request)
         if auth_code == 200:
-            log_message("INFO", f"getting variants for {id_}", request)
+            logger.log_message("INFO", f"getting variants for {id_}", request)
             return _get_urls("variant", escape(id_), reference_name, start, end, class_)
     else:
         return None, 404

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -11,10 +11,10 @@ import connexion
 import variants
 import indexing
 from pathlib import Path
+from candigv2_logging.logging import log_message
 
 
 app = Flask(__name__)
-
 
 # Endpoints
 def get_read_service_info():
@@ -122,6 +122,7 @@ def get_variants(id_=None, reference_name=None, start=None, end=None, class_=Non
     if id_ is not None:
         auth_code = authz.is_authed(escape(id_), request)
         if auth_code == 200:
+            log_message("INFO", f"getting variants for {id_}", request)
             return _get_urls("variant", escape(id_), reference_name, start, end, class_)
     else:
         return None, 404

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -10,10 +10,9 @@ import watchdog.events
 import hashlib
 import re
 import datetime
-import logging
+from candigv2_logging.logging import initialize, log_message
 
-
-logger = logging.getLogger(__file__)
+initialize()
 
 
 def index_variants(file_name=None):
@@ -25,9 +24,9 @@ def index_variants(file_name=None):
     else:
         return {"message": f"Format of file name is wrong: {file_name}"}, 500
 
-    logger.info(f"adding stats to {drs_obj_id}")
+    log_message("INFO",f"adding stats to {drs_obj_id}")
     calculate_stats(drs_obj_id)
-    logger.info(f"{drs_obj_id} stats done")
+    log_message("INFO",f"{drs_obj_id} stats done")
 
     gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
     if gen_obj is None:
@@ -38,19 +37,19 @@ def index_variants(file_name=None):
     if gen_obj['type'] == 'read':
         return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
 
-    logger.info(f"{drs_obj_id} starting indexing")
+    log_message("INFO",f"{drs_obj_id} starting indexing")
 
     headers = str(gen_obj['file'].header).split('\n')
 
     database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
-    logger.info(f"{drs_obj_id} indexed {len(headers)} headers")
+    log_message("INFO",f"{drs_obj_id} indexed {len(headers)} headers")
 
     samples = list(gen_obj['file'].header.samples)
     for sample in samples:
         if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
-            logger.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
+            log_message("WARNING",f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-    logger.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
+    log_message("INFO",f"{drs_obj_id} indexed {len(samples)} samples in file")
 
     contigs = {}
     for contig in list(gen_obj['file'].header.contigs):
@@ -72,14 +71,14 @@ def index_variants(file_name=None):
             positions.append(record.pos)
             normalized_contigs.append(normalized_contig_id)
         else:
-            logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
+            log_message("WARNING",f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
     res = create_position(to_create)
 
-    logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+    log_message("INFO",f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
     database.create_pos_bucket(res)
 
     database.mark_variantfile_as_indexed(drs_obj_id)
-    logger.info(f"{drs_obj_id} done")
+    log_message("INFO",f"{drs_obj_id} done")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 
@@ -127,7 +126,7 @@ def calculate_stats(obj_id):
         # if there are access methods, it's a file object
         file_obj = drs_operations._get_file_path(drs_json["id"])
         if file_obj["checksum"] is None:
-            logger.debug(f"calculating checksum for {drs_json['id']}")
+            log_message("DEBUG",f"calculating checksum for {drs_json['id']}")
             checksum = []
             with open(file_obj["path"], "rb") as f:
                 bytes = f.read()  # read file as bytes
@@ -135,7 +134,7 @@ def calculate_stats(obj_id):
                     "type": "sha-256",
                     "checksum": hashlib.sha256(bytes).hexdigest()
                 }]
-            logger.debug(f"done calculating checksum for {drs_json['id']}")
+            log_message("DEBUG",f"done calculating checksum for {drs_json['id']}")
             drs_json["checksums"] = checksum
         else:
             drs_json["checksums"] = [file_obj["checksum"]]
@@ -171,12 +170,12 @@ def index_touch_file(file_path):
         if status_code != 200:
             with open(file_path, "a") as f:
                 f.write(f"{datetime.datetime.today()} {response['message']}")
-        logger.info(response)
+        log_message("INFO",response)
         os.remove(file_path)
     except Exception as e:
         with open(file_path, "a") as f:
             f.write(f"{datetime.datetime.today()} {str(e)}")
-        logger.warning(str(e))
+        log_message("WARNING",str(e))
 
 
 class IndexingHandler(watchdog.events.FileSystemEventHandler):
@@ -206,19 +205,19 @@ if __name__ == "__main__":
         sys.exit()
 
     ## Otherwise, look for any backlog IDs, index those, then listen for new IDs to index.
-    logger.info(f"indexing started on {INDEXING_PATH}")
+    log_message("INFO",f"indexing started on {INDEXING_PATH}")
     to_index = os.listdir(INDEXING_PATH)
-    logger.info(f"Finishing backlog: indexing {to_index}")
+    log_message("INFO",f"Finishing backlog: indexing {to_index}")
     while len(to_index) > 0:
         try:
             file_path = f"{INDEXING_PATH}/{to_index.pop()}"
             index_touch_file(file_path)
         except Exception as e:
-            logger.warning(str(e))
+            log_message("WARNING",str(e))
         to_index = os.listdir(INDEXING_PATH)
 
     # now that the backlog is complete, listen for new files created:
-    logger.info(f"listening for new files at {INDEXING_PATH}")
+    log_message("INFO",f"listening for new files at {INDEXING_PATH}")
     event_handler = IndexingHandler()
     observer = Observer()
     observer.schedule(event_handler, INDEXING_PATH, recursive=False)

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -10,7 +10,10 @@ import watchdog.events
 import hashlib
 import re
 import datetime
-from candigv2_logging.logging import initialize, log_message
+from candigv2_logging.logging import initialize, CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 initialize()
 
@@ -24,9 +27,9 @@ def index_variants(file_name=None):
     else:
         return {"message": f"Format of file name is wrong: {file_name}"}, 500
 
-    log_message("INFO",f"adding stats to {drs_obj_id}")
+    logger.log_message("INFO",f"adding stats to {drs_obj_id}")
     calculate_stats(drs_obj_id)
-    log_message("INFO",f"{drs_obj_id} stats done")
+    logger.log_message("INFO",f"{drs_obj_id} stats done")
 
     gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
     if gen_obj is None:
@@ -37,19 +40,19 @@ def index_variants(file_name=None):
     if gen_obj['type'] == 'read':
         return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
 
-    log_message("INFO",f"{drs_obj_id} starting indexing")
+    logger.log_message("INFO",f"{drs_obj_id} starting indexing")
 
     headers = str(gen_obj['file'].header).split('\n')
 
     database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
-    log_message("INFO",f"{drs_obj_id} indexed {len(headers)} headers")
+    logger.log_message("INFO",f"{drs_obj_id} indexed {len(headers)} headers")
 
     samples = list(gen_obj['file'].header.samples)
     for sample in samples:
         if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
-            log_message("WARNING",f"Could not add sample {sample} to variantfile {drs_obj_id}")
+            logger.log_message("WARNING",f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-    log_message("INFO",f"{drs_obj_id} indexed {len(samples)} samples in file")
+    logger.log_message("INFO",f"{drs_obj_id} indexed {len(samples)} samples in file")
 
     contigs = {}
     for contig in list(gen_obj['file'].header.contigs):
@@ -71,14 +74,14 @@ def index_variants(file_name=None):
             positions.append(record.pos)
             normalized_contigs.append(normalized_contig_id)
         else:
-            log_message("WARNING",f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
+            logger.log_message("WARNING",f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
     res = create_position(to_create)
 
-    log_message("INFO",f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+    logger.log_message("INFO",f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
     database.create_pos_bucket(res)
 
     database.mark_variantfile_as_indexed(drs_obj_id)
-    log_message("INFO",f"{drs_obj_id} done")
+    logger.log_message("INFO",f"{drs_obj_id} done")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 
@@ -126,7 +129,7 @@ def calculate_stats(obj_id):
         # if there are access methods, it's a file object
         file_obj = drs_operations._get_file_path(drs_json["id"])
         if file_obj["checksum"] is None:
-            log_message("DEBUG",f"calculating checksum for {drs_json['id']}")
+            logger.log_message("DEBUG",f"calculating checksum for {drs_json['id']}")
             checksum = []
             with open(file_obj["path"], "rb") as f:
                 bytes = f.read()  # read file as bytes
@@ -134,7 +137,7 @@ def calculate_stats(obj_id):
                     "type": "sha-256",
                     "checksum": hashlib.sha256(bytes).hexdigest()
                 }]
-            log_message("DEBUG",f"done calculating checksum for {drs_json['id']}")
+            logger.log_message("DEBUG",f"done calculating checksum for {drs_json['id']}")
             drs_json["checksums"] = checksum
         else:
             drs_json["checksums"] = [file_obj["checksum"]]
@@ -170,12 +173,12 @@ def index_touch_file(file_path):
         if status_code != 200:
             with open(file_path, "a") as f:
                 f.write(f"{datetime.datetime.today()} {response['message']}")
-        log_message("INFO",response)
+        logger.log_message("INFO",response)
         os.remove(file_path)
     except Exception as e:
         with open(file_path, "a") as f:
             f.write(f"{datetime.datetime.today()} {str(e)}")
-        log_message("WARNING",str(e))
+        logger.log_message("WARNING",str(e))
 
 
 class IndexingHandler(watchdog.events.FileSystemEventHandler):
@@ -205,19 +208,19 @@ if __name__ == "__main__":
         sys.exit()
 
     ## Otherwise, look for any backlog IDs, index those, then listen for new IDs to index.
-    log_message("INFO",f"indexing started on {INDEXING_PATH}")
+    logger.log_message("INFO",f"indexing started on {INDEXING_PATH}")
     to_index = os.listdir(INDEXING_PATH)
-    log_message("INFO",f"Finishing backlog: indexing {to_index}")
+    logger.log_message("INFO",f"Finishing backlog: indexing {to_index}")
     while len(to_index) > 0:
         try:
             file_path = f"{INDEXING_PATH}/{to_index.pop()}"
             index_touch_file(file_path)
         except Exception as e:
-            log_message("WARNING",str(e))
+            logger.log_message("WARNING",str(e))
         to_index = os.listdir(INDEXING_PATH)
 
     # now that the backlog is complete, listen for new files created:
-    log_message("INFO",f"listening for new files at {INDEXING_PATH}")
+    logger.log_message("INFO",f"listening for new files at {INDEXING_PATH}")
     event_handler = IndexingHandler()
     observer = Observer()
     observer.schedule(event_handler, INDEXING_PATH, recursive=False)

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -3,7 +3,6 @@ import database
 from config import INDEXING_PATH
 from pysam import VariantFile, AlignmentFile
 import argparse
-import logging
 import os
 import sys
 from watchdog.observers import Observer
@@ -11,6 +10,10 @@ import watchdog.events
 import hashlib
 import re
 import datetime
+import logging
+
+
+logger = logging.getLogger(__file__)
 
 
 def index_variants(file_name=None):
@@ -22,9 +25,9 @@ def index_variants(file_name=None):
     else:
         return {"message": f"Format of file name is wrong: {file_name}"}, 500
 
-    logging.info(f"adding stats to {drs_obj_id}")
+    logger.info(f"adding stats to {drs_obj_id}")
     calculate_stats(drs_obj_id)
-    logging.info(f"{drs_obj_id} stats done")
+    logger.info(f"{drs_obj_id} stats done")
 
     gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
     if gen_obj is None:
@@ -35,19 +38,19 @@ def index_variants(file_name=None):
     if gen_obj['type'] == 'read':
         return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
 
-    logging.info(f"{drs_obj_id} starting indexing")
+    logger.info(f"{drs_obj_id} starting indexing")
 
     headers = str(gen_obj['file'].header).split('\n')
 
     database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
-    logging.info(f"{drs_obj_id} indexed {len(headers)} headers")
+    logger.info(f"{drs_obj_id} indexed {len(headers)} headers")
 
     samples = list(gen_obj['file'].header.samples)
     for sample in samples:
         if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
-            logging.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
+            logger.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-    logging.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
+    logger.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
 
     contigs = {}
     for contig in list(gen_obj['file'].header.contigs):
@@ -69,14 +72,14 @@ def index_variants(file_name=None):
             positions.append(record.pos)
             normalized_contigs.append(normalized_contig_id)
         else:
-            logging.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
+            logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
     res = create_position(to_create)
 
-    logging.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+    logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
     database.create_pos_bucket(res)
 
     database.mark_variantfile_as_indexed(drs_obj_id)
-    logging.info(f"{drs_obj_id} done")
+    logger.info(f"{drs_obj_id} done")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 
@@ -124,7 +127,7 @@ def calculate_stats(obj_id):
         # if there are access methods, it's a file object
         file_obj = drs_operations._get_file_path(drs_json["id"])
         if file_obj["checksum"] is None:
-            logging.debug(f"calculating checksum for {drs_json['id']}")
+            logger.debug(f"calculating checksum for {drs_json['id']}")
             checksum = []
             with open(file_obj["path"], "rb") as f:
                 bytes = f.read()  # read file as bytes
@@ -132,7 +135,7 @@ def calculate_stats(obj_id):
                     "type": "sha-256",
                     "checksum": hashlib.sha256(bytes).hexdigest()
                 }]
-            logging.debug(f"done calculating checksum for {drs_json['id']}")
+            logger.debug(f"done calculating checksum for {drs_json['id']}")
             drs_json["checksums"] = checksum
         else:
             drs_json["checksums"] = [file_obj["checksum"]]
@@ -168,12 +171,12 @@ def index_touch_file(file_path):
         if status_code != 200:
             with open(file_path, "a") as f:
                 f.write(f"{datetime.datetime.today()} {response['message']}")
-        logging.info(response)
+        logger.info(response)
         os.remove(file_path)
     except Exception as e:
         with open(file_path, "a") as f:
             f.write(f"{datetime.datetime.today()} {str(e)}")
-        logging.warning(str(e))
+        logger.warning(str(e))
 
 
 class IndexingHandler(watchdog.events.FileSystemEventHandler):
@@ -182,7 +185,6 @@ class IndexingHandler(watchdog.events.FileSystemEventHandler):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format=f'%(asctime)s %(levelname)s INDEXING: %(message)s')
     parser = argparse.ArgumentParser(description="index variant files")
 
     parser.add_argument("--id", help="drs object id", required=False)
@@ -204,19 +206,19 @@ if __name__ == "__main__":
         sys.exit()
 
     ## Otherwise, look for any backlog IDs, index those, then listen for new IDs to index.
-    logging.info(f"indexing started on {INDEXING_PATH}")
+    logger.info(f"indexing started on {INDEXING_PATH}")
     to_index = os.listdir(INDEXING_PATH)
-    logging.info(f"Finishing backlog: indexing {to_index}")
+    logger.info(f"Finishing backlog: indexing {to_index}")
     while len(to_index) > 0:
         try:
             file_path = f"{INDEXING_PATH}/{to_index.pop()}"
             index_touch_file(file_path)
         except Exception as e:
-            logging.warning(str(e))
+            logger.warning(str(e))
         to_index = os.listdir(INDEXING_PATH)
 
     # now that the backlog is complete, listen for new files created:
-    logging.info(f"listening for new files at {INDEXING_PATH}")
+    logger.info(f"listening for new files at {INDEXING_PATH}")
     event_handler = IndexingHandler()
     observer = Observer()
     observer.schedule(event_handler, INDEXING_PATH, recursive=False)

--- a/htsget_server/server.py
+++ b/htsget_server/server.py
@@ -2,6 +2,9 @@ from flask import Flask
 from flask_cors import CORS
 import connexion
 from config import PORT, DEBUG_MODE
+import candigv2_logging.logging
+
+candigv2_logging.logging.initialize()
 
 # Create the application instance
 app = connexion.App(__name__, specification_dir='./')
@@ -21,4 +24,4 @@ def index():
     return 'INDEX'
 
 if __name__ == '__main__':
-    app.run(port = PORT, debug=DEBUG_MODE)
+    app.run(port = PORT)

--- a/htsget_server/server.py
+++ b/htsget_server/server.py
@@ -1,7 +1,6 @@
 from flask import Flask
 from flask_cors import CORS
 import connexion
-import logging
 from config import PORT, DEBUG_MODE
 
 # Create the application instance

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -2,7 +2,10 @@ import os
 import re
 import database
 import drs_operations
-from candigv2_logging.logging import log_message
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
 
 
 def find_variants_in_region(reference_name=None, start=None, end=None):

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -2,6 +2,7 @@ import os
 import re
 import database
 import drs_operations
+from candigv2_logging.logging import log_message
 
 
 def find_variants_in_region(reference_name=None, start=None, end=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ sqlalchemy==1.4.44
 connexion==2.14.1
 MarkupSafe==2.1.1
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.2
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@develop
 pytest==7.2.0
 uwsgi==2.0.23
 connexion[swagger-ui]

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -3,7 +3,7 @@ module = wsgi:app
 chdir = htsget_server
 http = 0.0.0.0:3000
 
-master = true
+log-master = true
 processes = 4
 
 gid = candig


### PR DESCRIPTION
After rebuilding with this and https://github.com/CanDIG/CanDIGv2/pull/680, log messages should go into tmp/logging/buffer.*.log.