### PR TITLE
DIG-1750: use ~ instead of _

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ htsget_server/__pycache__/
 *.pyc
 __pycache__
 .nova/Configuration.json
+
+.DS_Store
+.idea/

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -103,7 +103,7 @@ def index_reads(id_=None):
         if "cohort" in drs_obj:
             cohort = drs_obj['cohort']
         try:
-            Path(f"{INDEXING_PATH}/{cohort}_{id_}").touch()
+            Path(f"{INDEXING_PATH}/{cohort}~{id_}").touch()
             return None, 200
         except Exception as e:
             return {"message": str(e)}, 500
@@ -174,7 +174,7 @@ def index_variants(id_=None, force=False, genome='hg38'):
                     return varfile, 200
                 # clear the indexed bit:
                 database.mark_variantfile_as_not_indexed(id_)
-            Path(f"{INDEXING_PATH}/{cohort}_{id_}").touch()
+            Path(f"{INDEXING_PATH}/{cohort}~{id_}").touch()
             return None, 200
         except Exception as e:
             return {"message": str(e)}, 500

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -20,7 +20,7 @@ initialize()
 
 def index_variants(file_name=None):
     # split file name into cohort and drs_obj_id
-    file_parse = re.match(r"(.*?)_(.+)", file_name)
+    file_parse = re.match(r"(.*?)~(.+)", file_name)
     if file_parse is not None:
         cohort = file_parse.group(1)
         drs_obj_id = file_parse.group(2)


### PR DESCRIPTION
Use a ~ to delimit instead of _ for indexing operations