### PR TITLE
Hotfix: speed up beacon searches

### DIFF
--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -40,7 +40,7 @@ def is_authed(id_, request):
 
 def get_authorized_cohorts(request):
     if is_testing(request):
-        return []
+        return ["test-htsget"]
     try:
         return authx.auth.get_opa_datasets(request)
     except Exception as e:


### PR DESCRIPTION
Similar to #329, beacon searches were authorizing with per-object instead of once per call.

To test: try a beacon call without this fix:
```
## beacon POST
curl -X "POST" "http://candig.docker.internal:5080/genomics/beacon/v2/g_variants" \
     -H 'Authorization: Bearer <token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "query": {
    "requestParameters": {
      "gene_id": "SLC2A5"
    }
  },
  "meta": {
    "apiVersion": "v2"
  }
}'
```
Note the time it takes and what the result counts are. Then recompose with the fix. When you run it again, you should get the same result, but in a much shorter time. This is more noticeable if you have a larger genomic dataset loaded.