### PR TITLE
DIG-1801: add switch for indexer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       SERVER_LOCAL_DATA: ${{github.workspace}}/data
       PGPASSWORD: OG0pjmnQDWUTvLotYrxPrg
       INDEXING_PATH: ${{github.workspace}}/tmp
+      INDEXING_SWITCH_FILE: ${{github.workspace}}/indexer_on
       TESTENV_URL: http://localhost:3000
       AGGREGATE_COUNT_THRESHOLD: 5
       POSTGRES_USERNAME: admin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         pip install -r requirements.txt
         bash create_db.sh
         mkdir -p ${{ env.INDEXING_PATH }}
+        touch ${{ env.INDEXING_SWITCH_FILE }}
         sed -i s@\<AGGREGATE_COUNT_THRESHOLD\>@${{env.AGGREGATE_COUNT_THRESHOLD}}@ config.ini
         sed -i s@\<POSTGRES_USERNAME\>@${{env.POSTGRES_USERNAME}}@ config.ini
     - name: Test

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ if [[ -f "initial_setup" ]]; then
 
     bash create_db.sh
     mkdir $INDEXING_PATH
+    touch $INDEXING_SWITCH_FILE
     rm initial_setup
 fi
 

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -36,3 +36,4 @@ if os.getenv("DEBUG_MODE", "1") == "1":
     DEBUG_MODE = True
 
 INDEXING_PATH = os.getenv("INDEXING_PATH", "~/tmp")
+INDEXING_SWITCH_FILE = os.getenv("INDEXING_SWITCH_FILE", "~/indexing_on")

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -193,7 +193,7 @@ def get_cohort_status(cohort_id):
 def _get_genomic_obj(object_id):
     result = {'status_code': 200}
     drs_obj = _describe_drs_object(object_id)
-    if drs_obj is None:
+    if drs_obj is None or 'message' in drs_obj:
         return { "message": f"{object_id} not found", "status_code": 404}
     index_result = _get_file_path(drs_obj['index'])
     if 'message' in index_result:

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -36,7 +36,7 @@ paths:
                                 type: object
         post:
             operationId: "htsget_operations.indexer_switch"
-            description: Get the status of the indexer
+            description: Set the indexer on or off
             parameters:
                 - in: query
                   name: status

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -23,6 +23,37 @@ paths:
                5XX:
                    '$ref': '#/components/responses/5xxServerError'
 
+    /indexer:
+        get:
+            operationId: "htsget_operations.indexer_status"
+            description: Get the status of the indexer
+            responses:
+                200:
+                    description: Indexer status
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+        post:
+            operationId: "htsget_operations.indexer_switch"
+            description: Get the status of the indexer
+            parameters:
+                - in: query
+                  name: status
+                  description: set the indexer to be on or off
+                  required: true
+                  schema:
+                      type: string
+                      enum: ["ON", "OFF"]
+
+            responses:
+                200:
+                    description: Indexer status
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+
     /reads/{id}:
         get:
             tags:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -189,6 +189,8 @@ def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
         drs_obj = database.get_drs_object(id_)
         if drs_obj is None:
             return {"message": f"No DRS object exists with ID {id_}"}, 404
+        if drs_obj['description'] not in ['wgs', 'wts']:
+            return {"message": f"DRS object {id_} is not a genomic object"}, 404
         cohort = ""
         if "cohort" in drs_obj:
             cohort = drs_obj['cohort']

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 import drs_operations
 import database
 import authz
-from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH
+from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH, INDEXING_SWITCH_FILE
 from markupsafe import escape
 import connexion
 import variants
@@ -66,6 +66,28 @@ def get_variant_service_info():
             "tagsParametersEffective": False
         }
     }
+
+
+def indexer_status():
+    if os.path.isfile(INDEXING_SWITCH_FILE):
+        return {"status": "ON"}, 200
+    return {"status": "OFF"}, 200
+
+
+def indexer_switch(status=None):
+    if status == "ON":
+        try:
+            open(INDEXING_SWITCH_FILE, "x")
+            return {"status": "ON"}, 200
+        except Exception as e:
+            return {"error": f"indexer switch error {status}:  {type(e)} {str(e)}"}, 500
+    if status == "OFF":
+        try:
+            if os.path.isfile(INDEXING_SWITCH_FILE):
+                os.remove(INDEXING_SWITCH_FILE)
+            return {"status": "OFF"}, 200
+        except Exception as e:
+            return {"error": f"indexer switch error {status}: {type(e)} {str(e)}"}, 500
 
 
 @app.route('/reads/<path:id_>')

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -183,11 +183,6 @@ def calculate_stats(obj_id):
 ## When a file is created, index the variant with the ID of that filename.
 ## These are created at htsget_operations.index_variants.
 def index_touch_file(file_path):
-    ## if the indexing_on file is not present, exit
-    if not os.path.isfile(INDEXING_SWITCH_FILE):
-        logger.debug(f"{INDEXING_SWITCH_FILE} is not present; exiting")
-        sys.exit(10)
-
     try:
         name = file_path.replace(INDEXING_PATH, "").replace("/", "")
         logger.info(f"indexing {name}, files to index: " + str(os.listdir(INDEXING_PATH)))
@@ -254,6 +249,10 @@ if __name__ == "__main__":
     observer.start()
     try:
         while observer.is_alive():
+            ## if the indexing_on file is not present, exit
+            if not os.path.isfile(INDEXING_SWITCH_FILE):
+                logger.debug(f"{INDEXING_SWITCH_FILE} is not present; exiting")
+                sys.exit(10)
             observer.join(1)
     finally:
         observer.stop()

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -1,6 +1,6 @@
 import drs_operations
 import database
-from config import INDEXING_PATH
+from config import INDEXING_PATH, INDEXING_SWITCH_FILE
 from pysam import VariantFile, AlignmentFile
 import argparse
 import os
@@ -183,6 +183,11 @@ def calculate_stats(obj_id):
 ## When a file is created, index the variant with the ID of that filename.
 ## These are created at htsget_operations.index_variants.
 def index_touch_file(file_path):
+    ## if the indexing_on file is not present, exit
+    if not os.path.isfile(INDEXING_SWITCH_FILE):
+        logger.debug(f"{INDEXING_SWITCH_FILE} is not present; exiting")
+        sys.exit(10)
+
     try:
         name = file_path.replace(INDEXING_PATH, "").replace("/", "")
         logger.info(f"indexing {name}, files to index: " + str(os.listdir(INDEXING_PATH)))
@@ -195,7 +200,7 @@ def index_touch_file(file_path):
     except Exception as e:
         with open(file_path, "a") as f:
             f.write(f"{datetime.datetime.today()} {str(e)}")
-        logger.warning(str(e))
+        logger.warning(f"indexing error! {type(e)} {str(e)}")
 
 
 class IndexingHandler(watchdog.events.FileSystemEventHandler):
@@ -223,6 +228,11 @@ if __name__ == "__main__":
         varfile = database.create_variantfile({"id": args.id, "reference_genome": args.genome})
         index_variants(drs_obj_id=f"{cohort}_{args.id}")
         sys.exit()
+
+    ## if the indexing_on file is not present, exit
+    if not os.path.isfile(INDEXING_SWITCH_FILE):
+        logger.debug(f"{INDEXING_SWITCH_FILE} is not present; exiting")
+        sys.exit(10)
 
     ## Otherwise, look for any backlog IDs, index those, then listen for new IDs to index.
     logger.info(f"indexing started on {INDEXING_PATH}")

--- a/htsget_server/indexing.sh
+++ b/htsget_server/indexing.sh
@@ -1,6 +1,8 @@
 until python htsget_server/indexing.py; do
     if [[ $? != 10 ]]; then
         echo "Indexing crashed with exit code $?.  Respawning..." >&2
+    else
+        echo "indexer OFF"
     fi
     sleep 10
 done

--- a/htsget_server/indexing.sh
+++ b/htsget_server/indexing.sh
@@ -1,4 +1,6 @@
 until python htsget_server/indexing.py; do
-    echo "Indexing crashed with exit code $?.  Respawning.." >&2
-    sleep 1
+    if [[ $? != 10 ]]; then
+        echo "Indexing crashed with exit code $?.  Respawning..." >&2
+    fi
+    sleep 10
 done

--- a/htsget_server/indexing.sh
+++ b/htsget_server/indexing.sh
@@ -1,6 +1,7 @@
 until python htsget_server/indexing.py; do
-    if [[ $? != 10 ]]; then
-        echo "Indexing crashed with exit code $?.  Respawning..." >&2
+    status=$?
+    if [[ $status != 10 ]]; then
+        echo "Indexing crashed with exit code $status.  Respawning..." >&2
     else
         echo "indexer OFF"
     fi

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -37,6 +37,14 @@ def get_headers():
     return headers
 
 
+def test_indexer_on():
+    headers = get_headers()
+    url = f"{HOST}/htsget/v1/indexer"
+    response = requests.request("GET", url, headers=headers)
+    if response.status_code == 200:
+        assert response.json()['status'] == "ON"
+
+
 def test_remove_objects(cohorts):
     headers = get_headers()
     candig_url = os.getenv("CANDIG_URL")


### PR DESCRIPTION
Added endpoints for turning the indexer on and off (and to check its status). 

The switch works by checking for the presence of the INDEXING_SWITCH_FILE: if it is absent at startup, the indexer quits; if it is present at startup but gets removed later, the next time something triggers the indexer, it will check for the file and quit if it's not there.

The indexing.sh loop takes care of the rest: if the indexing script is not running, it will respawn and the check will happen again.

You can manually test by setting the indexer status on and off and then running `GET http://candig.docker.internal:5080/genomics/htsget/v1/variants/LOCAL-multisample_1/index?force=true` to force an indexing.

I also added a few other exception catches for a weird edge case I ran into: if you try to index a DRS object that isn't something indexable, it should fail gracefully. The case I ran into was `GET http://candig.docker.internal:5080/genomics/htsget/v1/variants/multisample_1.vcf.gz/index?force=true`: before, it would throw a KeyError exception over and over again. Now it fails before being sent to the indexer.