### PR TITLE
Bumping candigv2 library versions; consolidating auth stuff

### DIFF
--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -24,7 +24,7 @@ class AuthzRequest:
 
 
 def is_testing(request):
-    if request.headers.get("Authorization") == f"Bearer {TEST_KEY}":
+    if "Authorization" in request.headers and request.headers["Authorization"] == f"Bearer {TEST_KEY}":
         logger.warning("TEST MODE, AUTHORIZATION IS DISABLED")
         return True
 
@@ -34,9 +34,7 @@ def is_authed(id_, request):
         return 401
     if is_testing(request):
         return 200 # no auth
-    if request_is_from_ingest(request):
-        return 200
-    if request_is_from_query(request):
+    if has_full_authz(request):
         return 200
     if "Authorization" in request.headers:
         obj = database.get_drs_object(id_)
@@ -51,10 +49,13 @@ def is_authed(id_, request):
 
 
 def get_authorized_programs(request):
-    if is_testing(request):
+    req = AuthzRequest(request.headers, request.method, request.url.path)
+    if has_full_authz(req):
+        return map(lambda x: x['id'], database.list_programs())
+    if is_testing(req):
         return ["test-htsget"]
     try:
-        return authx.auth.get_opa_datasets(AuthzRequest(request.headers, request.method, request.url.path))
+        return authx.auth.get_opa_datasets(req)
     except Exception as e:
         logger.warning(f"Couldn't authorize programs: {type(e)} {str(e)}")
         return []
@@ -64,26 +65,26 @@ def is_program_authorized(request, program_id):
     req = AuthzRequest(request.headers, request.method, request.url.path)
     if is_testing(req):
         return True
-    if request_is_from_ingest(req):
+    if has_full_authz(req):
         return True
     if not "Authorization" in request.headers:
         return False
     return authx.auth.is_action_allowed_for_program(authx.auth.get_auth_token(req), method=req.method, path=req.path, program=program_id)
 
 
-def is_site_admin(request):
+def has_full_authz(request):
     """
-    Is the user associated with the token a site admin?
+    Is the user associated with the token a site admin? Alternately, is this request from query or ingest?
     """
     if is_testing(request):
         return True
-    if request_is_from_ingest(request):
+    if request_is_from_ingest(request) or request_is_from_query(request):
         return True
     if "Authorization" in request.headers:
         try:
-            return authx.auth.is_site_admin(AuthzRequest(request.headers, request.method, request.url.path))
+            return authx.auth.has_full_authz(AuthzRequest(request.headers, request.method, request.url.path))
         except Exception as e:
-            logger.warning(f"Couldn't authorize site_admin: {type(e)} {str(e)}")
+            logger.warning(f"Couldn't authorize for full access: {type(e)} {str(e)}")
             return False
     return False
 

--- a/htsget_server/authz.py
+++ b/htsget_server/authz.py
@@ -51,7 +51,7 @@ def is_authed(id_, request):
 def get_authorized_programs(request):
     req = AuthzRequest(request.headers, request.method, request.url.path)
     if has_full_authz(req):
-        return map(lambda x: x['id'], database.list_programs())
+        return list(map(lambda x: x['id'], database.list_programs()))
     if is_testing(req):
         return ["test-htsget"]
     try:
@@ -82,7 +82,7 @@ def has_full_authz(request):
         return True
     if "Authorization" in request.headers:
         try:
-            return authx.auth.has_full_authz(AuthzRequest(request.headers, request.method, request.url.path))
+            return authx.auth.is_site_admin(AuthzRequest(request.headers, request.method, request.url.path))
         except Exception as e:
             logger.warning(f"Couldn't authorize for full access: {type(e)} {str(e)}")
             return False

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -118,7 +118,7 @@ def list_programs():
     if programs is None:
         return [], 404
     try:
-        if authz.is_site_admin(connexion.request) or authz.request_is_from_query(connexion.request):
+        if authz.has_full_authz(connexion.request):
             return list(map(lambda x: x['id'], programs)), 200
         authorized_programs = authz.get_authorized_programs(connexion.request)
         return list(set(map(lambda x: x['id'], programs)).intersection(set(authorized_programs))), 200
@@ -138,7 +138,7 @@ def get_program(program_id):
     new_program = database.get_program(program_id)
     if new_program is None:
         return {"message": "No matching program found"}, 404
-    if authz.is_program_authorized(connexion.request, program_id) or authz.request_is_from_query(connexion.request):
+    if authz.is_program_authorized(connexion.request, program_id):
         return new_program, 200
     return {"message": f"Not authorized to access program {program_id}"}, 403
 

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -118,8 +118,6 @@ def list_programs():
     if programs is None:
         return [], 404
     try:
-        if authz.has_full_authz(connexion.request):
-            return list(map(lambda x: x['id'], programs)), 200
         authorized_programs = authz.get_authorized_programs(connexion.request)
         return list(set(map(lambda x: x['id'], programs)).intersection(set(authorized_programs))), 200
     except Exception as e:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -116,7 +116,7 @@ def get_reads_data(id_, reference_name=None, format_="bam", start=None, end=None
 
 @app.route('/reads/<path:id_>/index')
 def index_reads(id_=None):
-    if not authz.is_site_admin(connexion.request):
+    if not authz.has_full_authz(connexion.request):
         return {"message": "User is not authorized to index reads"}, 403
     if id_ is not None:
         # check that there is a database drs object for this:
@@ -184,7 +184,7 @@ def verify_variants_genomic_drs_object(id_):
 
 @app.route('/variants/<path:id_>/index')
 def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
-    if not authz.is_site_admin(connexion.request):
+    if not authz.has_full_authz(connexion.request):
         return {"message": "User is not authorized to index variants"}, 403
     if id_ is not None:
         # check that there is a database drs object for this:
@@ -301,18 +301,10 @@ def _get_samples(samples):
             if res["program"] not in samples_by_program:
                 samples_by_program[res["program"]] = []
             samples_by_program[res["program"]].append(res)
-    if authz.is_testing(connexion.request):
-        for program in samples_by_program:
+    authz_programs = authz.get_authorized_programs(connexion.request)
+    for program in authz_programs:
+        if program in samples_by_program:
             result.extend(samples_by_program[program])
-    else:
-        if authz.request_is_from_query(connexion.request) or authz.request_is_from_ingest(connexion.request):
-            for program in samples_by_program:
-                result.extend(samples_by_program[program])
-        else:
-            authz_programs = authz.get_authorized_programs(connexion.request)
-            for program in authz_programs:
-                if program in samples_by_program:
-                    result.extend(samples_by_program[program])
     return result
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ pysam==0.22.0
 sqlalchemy==1.4.44
 connexion==3.1.0
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.5.0
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 pytest==8.3.3
 connexion[swagger-ui]
 connexion[flask]


### PR DESCRIPTION
I was only intending to bump the authx/logging versions to the most updated versions, but then I realized that the authz stuff had gotten a bit out of hand. I changed is_site_admin to represent has_full_authz (so that a request that is fully authorized would include ones from site admins and also from query or ingest services). I also changed get_authorized_programs to return all programs for a fully authzed request.

Testing still passes for both the htsget pytest and for the integration tests.