### PR TITLE
hotfix: bump authx to v2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.22.0
 sqlalchemy==1.4.44
 connexion==3.1.0
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.1
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.2
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 pytest==8.3.3
 connexion[swagger-ui]


### PR DESCRIPTION
Pick up fix in https://github.com/CanDIG/candigv2-authx/pull/39