### PR TITLE
DIG-1918: indexer switch needs to be authz

### DIFF
--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -75,6 +75,8 @@ def indexer_status():
 
 
 def indexer_switch(status=None):
+    if not authz.has_full_authz(connexion.request):
+        return {"message": "User is not authorized to switch indexer"}, 403
     if status == "ON":
         try:
             open(INDEXING_SWITCH_FILE, "x")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysam==0.22.0
 sqlalchemy==1.4.44
 connexion==3.1.0
 MarkupSafe==2.1.1
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.6.2
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.7.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
 pytest==8.3.3
 connexion[swagger-ui]


### PR DESCRIPTION
Add a check for full authz (site admin) for endpoint to switch the indexer on and off.

To test:
```
curl -X "POST" "http://candig.docker.internal:5080/genomics/htsget/v1/indexer?status=ON"
```
with a site admin bearer token works; any other token gives you a 403 error.