### PR TITLE
DIG-1925: rename GenomicDrsObject to AnalysisDrsObject

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -486,7 +486,7 @@ def create_drs_object(obj, tries=1):
             session.add(new_object)
             session.commit()
 
-            # if we have reference_genome info, it's a GenomicDrsObject and needs a variantfile:
+            # if we have reference_genome info, it's a AnalysisDrsObject and needs a variantfile:
             if 'reference_genome' in obj:
                 create_variantfile({"id": obj["id"], "reference_genome": obj["reference_genome"]})
 
@@ -509,7 +509,7 @@ def delete_drs_object(obj_id, tries=1):
             new_object = session.query(DrsObject).filter_by(id=obj_id).one()
             program = session.query(Program).filter_by(id=new_object.program_id).one_or_none()
             if new_object.description in ["wgs", "wts"]:
-                # this is a GenomicDrsObject; we need to delete any indexed variantfiles
+                # this is a AnalysisDrsObject; we need to delete any indexed variantfiles
                 variantfiles = session.query(VariantFile).filter_by(drs_object_id=new_object.id).all()
                 for vf in variantfiles:
                     session.delete(vf)

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -45,9 +45,9 @@ paths:
                 items:
                   anyOf:
                     - $ref: '#/components/schemas/SampleDrsObject'
-                    - $ref: '#/components/schemas/GenomicDrsObject'
-                    - $ref: '#/components/schemas/GenomicDataDrsObject'
-                    - $ref: '#/components/schemas/GenomicIndexDrsObject'
+                    - $ref: '#/components/schemas/AnalysisDrsObject'
+                    - $ref: '#/components/schemas/AnalysisDataDrsObject'
+                    - $ref: '#/components/schemas/AnalysisIndexDrsObject'
       tags:
         - Objects
     post:
@@ -92,7 +92,7 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/GenomicDrsObject'
+                  - $ref: '#/components/schemas/AnalysisDrsObject'
       tags:
         - Objects
 
@@ -266,9 +266,9 @@ components:
           schema:
             anyOf:
               - $ref: "#/components/schemas/SampleDrsObject"
-              - $ref: "#/components/schemas/GenomicDrsObject"
-              - $ref: "#/components/schemas/GenomicDataDrsObject"
-              - $ref: "#/components/schemas/GenomicIndexDrsObject"
+              - $ref: "#/components/schemas/AnalysisDrsObject"
+              - $ref: "#/components/schemas/AnalysisDataDrsObject"
+              - $ref: "#/components/schemas/AnalysisIndexDrsObject"
     ProgramRequest:
       content:
         'application/json':
@@ -292,17 +292,17 @@ components:
       type: object
       properties:
         index_complete:
-          description: DrsUris for variant genomic objects that have been successfully indexed
+          description: DrsUris for variant objects that have been successfully indexed
           type: array
           items:
             $ref: '#/components/schemas/DrsUri'
         index_in_progress:
-          description: DrsUris for variant genomic objects that have not yet been indexed
+          description: DrsUris for variant objects that have not yet been indexed
           type: array
           items:
             $ref: '#/components/schemas/DrsUri'
         index_errored:
-          description: DrsUris for variant genomic objects that are in the queue to be indexed
+          description: DrsUris for variant objects that are in the queue to be indexed
           type: array
           items:
             type: object
@@ -318,7 +318,7 @@ components:
       description: a DRS object's self_uri
     SampleDrsObject:
       type: object
-      description: A DrsObject that describes the clinical sample used for genomic analysis.
+      description: A DrsObject that describes the clinical sample used for sequencing.
       required:
         - id
         - contents
@@ -384,10 +384,10 @@ components:
             = f7a29a04
         contents:
           type: array
-          description: The specific genomic contents objects that were generated from this sample.
+          description: The specific analysis contents objects that were generated from this sample.
           minItems: 1
           items:
-            $ref: '#/components/schemas/GenomicContentsObject'
+            $ref: '#/components/schemas/AnalysisContentsObject'
         description:
           type: string
           enum:
@@ -404,9 +404,9 @@ components:
             about this `DrsObject` from external metadata sources. These
             aliases can be used to represent secondary
             accession numbers or external GUIDs.
-    GenomicDrsObject:
+    AnalysisDrsObject:
       type: object
-      description: A DrsObject that describes a bundled genomic data entity. It usually will consist of a genomic data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Samples (as SampleContentObjects), ordered in order of appearance in the associated variant/read files.
+      description: A DrsObject that describes a sequencing analysis. It usually will consist of a data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Samples (as SampleContentObjects), ordered in order of appearance in the associated variant/read files.
       required:
         - id
         - contents
@@ -420,7 +420,7 @@ components:
       properties:
         id:
           type: string
-          description: The descriptor for this genomic data entity
+          description: The descriptor for this analysis data entity
         name:
           type: string
           description: |-
@@ -514,7 +514,7 @@ components:
             accession numbers or external GUIDs.
     GenomicDataDrsObject:
       type: object
-      description: A DrsObject that describes a genomic data file, e.g. a variant or read file.
+      description: A DrsObject that describes a analysis data file, e.g. a variant or read file.
       required:
         - id
         - access_methods
@@ -527,7 +527,7 @@ components:
       properties:
         id:
           type: string
-          description: The filename for this genomic data file, including its file extensions.
+          description: The filename for this analysis data file, including its file extensions.
         name:
           type: string
           description: |-
@@ -610,9 +610,9 @@ components:
             about this `DrsObject` from external metadata sources. These
             aliases can be used to represent secondary
             accession numbers or external GUIDs.
-    GenomicIndexDrsObject:
+    AnalysisIndexDrsObject:
       type: object
-      description: A DrsObject that describes a genomic index file associated with a genomic drs object
+      description: A DrsObject that describes an index file associated with an analysis drs object
       required:
         - id
         - access_methods
@@ -625,7 +625,7 @@ components:
       properties:
         id:
           type: string
-          description: The filename for this genomic index file, including its file extensions.
+          description: The filename for this index file, including its file extensions.
         name:
           type: string
           description: |-
@@ -768,7 +768,7 @@ components:
       anyOf:
         - $ref: '#/components/schemas/LocalFileAccessMethod'
         - $ref: '#/components/schemas/S3AccessMethod'
-    GenomicContentsObject:
+    AnalysisContentsObject:
       type: object
       required:
         - name
@@ -776,13 +776,13 @@ components:
       properties:
         name:
           type: string
-          description: The identifier of the genomic object
+          description: The identifier of the analysis object
         id:
           type: string
-          description: The identifier of the genomic object
+          description: The identifier of the analysis object
         drs_uri:
           type: array
-          description: The DRS uri(s) to the GenomicDrsObject
+          description: The DRS uri(s) to the AnalysisDrsObject
           items:
             type: string
     SampleContentsObject:
@@ -802,7 +802,7 @@ components:
           description: The DRS uri(s) to the SampleDrsObject
           items:
             type: string
-    GenomicDataContentsObject:
+    AnalysisDataContentsObject:
       type: object
       required:
         - name
@@ -810,7 +810,7 @@ components:
       properties:
         name:
           type: string
-          description: The full filename of the genomic data file, including extensions.
+          description: The full filename of the analysis data file, including extensions.
         id:
           type: string
           enum:
@@ -818,10 +818,10 @@ components:
             - read
         drs_uri:
           type: array
-          description: The DRS uri(s) to the GenomicDataDrsObject
+          description: The DRS uri(s) to the AnalysisDataDrsObject
           items:
             type: string
-    GenomicIndexContentsObject:
+    AnalysisIndexContentsObject:
       type: object
       required:
         - name
@@ -829,13 +829,13 @@ components:
       properties:
         name:
           type: string
-          description: The full filename of the genomic index file, including extensions.
+          description: The full filename of the index file, including extensions.
         id:
           type: string
           enum:
             - index
         drs_uri:
           type: array
-          description: The DRS uri(s) to the GenomicIndexDrsObject
+          description: The DRS uri(s) to the AnalysisIndexDrsObject
           items:
             type: string

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -426,6 +426,42 @@ components:
           description: |-
             The filename for this entity, not including its file extensions.
             This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+        contents:
+          type: array
+          description: The specific analysis contents objects that comprise this analysis DRS entity. Should contain a AnalysisDataContentsObject, an optional AnalysisIndexContentsObject, and SampleContentsObjects corresponding to the samples analyzed in the analysis data object.
+          minItems: 1
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/AnalysisDataContentsObject'
+              - $ref: '#/components/schemas/AnalysisIndexContentsObject'
+              - $ref: '#/components/schemas/SampleContentsObject'
+        description:
+          type: string
+          description: type of sequencing analysis
+          enum:
+            - wgs
+            - wts
+        program:
+          type: string
+          description: The program this object was ingested as part of
+        reference_genome:
+          type: string
+          description: the reference genome used to compile this analysis
+          enum:
+            - hg37
+            - hg38
+        indexed:
+          type: integer
+          description: 1 if the object has been indexed for search, 0 if not
+        aliases:
+          type: array
+          items:
+            type: string
+          description: >-
+            A list of strings that can be used to find other metadata
+            about this `DrsObject` from external metadata sources. These
+            aliases can be used to represent secondary
+            accession numbers or external GUIDs.
         self_uri:
           type: string
           description: |-
@@ -476,43 +512,7 @@ components:
             = md5( concat( 5e089d29, 72794b6d ) )
             = md5( 5e089d2972794b6d )
             = f7a29a04
-        contents:
-          type: array
-          description: The specific genomic contents objects that comprise this genomic DRS entity. Should contain a GenomicDataContentsObject, an optional GenomicIndexContentsObject, and SampleContentsObjects corresponding to the samples analyzed in the genomic data object.
-          minItems: 1
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/GenomicDataContentsObject'
-              - $ref: '#/components/schemas/GenomicIndexContentsObject'
-              - $ref: '#/components/schemas/SampleContentsObject'
-        description:
-          type: string
-          description: type of sequencing data
-          enum:
-            - wgs
-            - wts
-        program:
-          type: string
-          description: The program this object was ingested as part of
-        reference_genome:
-          type: string
-          description: the reference genome used to compile this genomic object
-          enum:
-            - hg37
-            - hg38
-        indexed:
-          type: integer
-          description: 1 if the object has been indexed for search, 0 if not
-        aliases:
-          type: array
-          items:
-            type: string
-          description: >-
-            A list of strings that can be used to find other metadata
-            about this `DrsObject` from external metadata sources. These
-            aliases can be used to represent secondary
-            accession numbers or external GUIDs.
-    GenomicDataDrsObject:
+    AnalysisDataDrsObject:
       type: object
       description: A DrsObject that describes a analysis data file, e.g. a variant or read file.
       required:
@@ -533,6 +533,21 @@ components:
           description: |-
             The filename for this entity, not including its file extensions.
             This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+        access_methods:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/AccessMethod"
+          description: |-
+            The list of access methods that can be used to fetch the `DrsObject`.
+        description:
+          type: string
+          enum:
+            - variant
+            - read
+        program:
+            type: string
+            description: The program this object was ingested as part of
         self_uri:
           type: string
           description: |-
@@ -583,21 +598,6 @@ components:
             = md5( concat( 5e089d29, 72794b6d ) )
             = md5( 5e089d2972794b6d )
             = f7a29a04
-        access_methods:
-          type: array
-          minItems: 1
-          items:
-            $ref: "#/components/schemas/AccessMethod"
-          description: |-
-            The list of access methods that can be used to fetch the `DrsObject`.
-        description:
-          type: string
-          enum:
-            - variant
-            - read
-        program:
-            type: string
-            description: The program this object was ingested as part of
         mime_type:
           type: string
           description: A string providing the mime-type of the DrsObject.

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Data Repository Service
-  version: 1.2.0
+  version: 1.3.0
   termsOfService: 'https://www.ga4gh.org/terms-and-conditions/'
   license:
     name: Apache 2.0

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -441,6 +441,7 @@ components:
           enum:
             - wgs
             - wts
+            - downstream
         program:
           type: string
           description: The program this object was ingested as part of
@@ -545,6 +546,7 @@ components:
           enum:
             - variant
             - read
+            - transcript
         program:
             type: string
             description: The program this object was ingested as part of
@@ -816,6 +818,7 @@ components:
           enum:
             - variant
             - read
+            - transcript
         drs_uri:
           type: array
           description: The DRS uri(s) to the AnalysisDataDrsObject

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -190,7 +190,7 @@ def get_program_status(program_id):
 # particular sample can have a variant or read file and an associated index file.
 # We need to query DRS to get the bundling object, which should contain links to
 # two contents objects.
-def _get_genomic_obj(object_id):
+def _get_analysis_obj(object_id):
     result = {'status_code': 200}
     drs_obj = _describe_drs_object(object_id)
     if drs_obj is None or 'message' in drs_obj:
@@ -213,7 +213,7 @@ def _get_genomic_obj(object_id):
                 else:
                     result['file'] = VariantFile(main_result['path'], index_filename=index_result['path'])
             except Exception as e:
-                return { "message": str(e), "status_code": 500, "method": f"_get_genomic_obj({object_id})"}
+                return { "message": str(e), "status_code": 500, "method": f"_get_analysis_obj({object_id})"}
     return result
 
 
@@ -228,7 +228,7 @@ def _describe_drs_object(object_id):
     # drs_obj should have a main contents, index contents, and sample contents
     if "contents" in drs_obj:
         for contents in drs_obj["contents"]:
-            # get each drs object (should be the genomic file and its index)
+            # get each drs object (should be the analysis file and its index)
             # if sub_obj.name matches an index file regex, it's an index file
             index_match = re.fullmatch(r'.+\.(...*i)$', contents["name"])
 

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -186,7 +186,7 @@ paths:
            tags:
                - Reads
            summary: Verify the integrity of the read object
-           operationId: "htsget_operations.verify_reads_genomic_drs_object"
+           operationId: "htsget_operations.verify_reads_analysis_drs_object"
            description: |
                Verify the integrity of the read object
            parameters:
@@ -289,7 +289,7 @@ paths:
             tags:
                 - Variants
             summary: Verify the integrity of the variant object
-            operationId: "htsget_operations.verify_variants_genomic_drs_object"
+            operationId: "htsget_operations.verify_variants_analysis_drs_object"
             description: |
                 Verify the integrity of the variant object
             parameters:
@@ -332,7 +332,7 @@ paths:
                 - $ref: '#/components/parameters/endParam'
             responses:
                 200:
-                    description: Successfully streamed file part of large genomic variant file
+                    description: Successfully streamed file part of large variant file
                     content:
                         application/octet-stream:
                             schema:
@@ -908,22 +908,22 @@ components:
                     description: MoH program ID
                 genome:
                     type: array
-                    description: An array of associated GenomicDrsObjects that describe reads, e.g. bams.
+                    description: An array of associated AnalysisDrsObjects that describe reads, e.g. fastqs.
                     items:
                         type: string
                 transcriptome:
                     type: array
-                    description: An array of associated GenomicDrsObjects that describe transcriptome data.
+                    description: An array of associated AnalysisDrsObjects that describe transcriptome data.
                     items:
                         type: string
                 variants:
                     type: array
-                    description: An array of associated GenomicDataDrsObjects that describe variant files.
+                    description: An array of associated AnalysisDataDrsObjects that describe variant files.
                     items:
                         type: string
                 reads:
                     type: array
-                    description: An array of associated GenomicDataDrsObjects that describe read files.
+                    description: An array of associated AnalysisDataDrsObjects that describe read files, e.g. bams.
                     items:
                         type: string
 

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -138,9 +138,9 @@ def index_reads(id_=None):
 
 
 @app.route('/reads/<path:id_>/verify')
-def verify_reads_genomic_drs_object(id_):
+def verify_reads_analysis_drs_object(id_):
     try:
-        _verify_genomic_drs_object(id_)
+        _verify_analysis_drs_object(id_)
     except Exception as e:
         return {"result": False, "message": str(e)}, 200
     return {"result": True}, 200
@@ -172,11 +172,11 @@ def get_variants_data(id_, reference_name=None, format_="VCF", start=None, end=N
 
 
 @app.route('/variants/<path:id_>/verify')
-def verify_variants_genomic_drs_object(id_):
+def verify_variants_analysis_drs_object(id_):
     try:
         auth_code = authz.is_authed(escape(id_), connexion.request)
         if auth_code == 200:
-            _verify_genomic_drs_object(id_)
+            _verify_analysis_drs_object(id_)
         else:
             return {"message": "User is not authorized to verify variants"}, 403
     except Exception as e:
@@ -194,7 +194,7 @@ def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
         if drs_obj is None:
             return {"message": f"No DRS object exists with ID {id_}"}, 404
         if drs_obj['description'] not in ['wgs', 'wts']:
-            return {"message": f"DRS object {id_} is not a genomic object"}, 404
+            return {"message": f"DRS object {id_} is not a analysis object"}, 404
         program = ""
         if "program" in drs_obj:
             program = drs_obj['program']
@@ -319,8 +319,8 @@ def _get_sample(id_=None):
         "reads": []
     }
 
-    # Get the SampleDrsObject. It will have a contents array of GenomicContentsObjects > GenomicDrsObjects.
-    # Each of those GenomicDrsObjects will have a description that is either 'wgs' or 'wts'.
+    # Get the SampleDrsObject. It will have a contents array of AnalysisContentsObjects > AnalysisDrsObjects.
+    # Each of those AnalysisDrsObjects will have a description that is either 'wgs' or 'wts'.
     sample_drs_obj = database.get_drs_object(id_)
     if sample_drs_obj is not None and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
         result["program"] = sample_drs_obj["program"]
@@ -331,7 +331,7 @@ def _get_sample(id_=None):
                     result["genomes"].append(drs_obj["id"])
                 elif drs_obj["description"] == "wts":
                     result["transcriptomes"].append(drs_obj["id"])
-                # check the contents of this genomic drs object and see if it contains variants or reads
+                # check the contents of this analysis drs object and see if it contains variants or reads
                 if "contents" in drs_obj:
                     for content in drs_obj["contents"]:
                         if content["id"] == "variant":
@@ -459,7 +459,7 @@ def _get_data(id_, reference_name=None, start=None, end=None, class_=None, forma
     file_name = f"{id_}.{format_}"
 
     # get a file and index from drs, based on the id_
-    gen_obj = drs_operations._get_genomic_obj(id_)
+    gen_obj = drs_operations._get_analysis_obj(id_)
     if gen_obj is not None:
         if "message" in gen_obj:
             return gen_obj['message'], gen_obj['status_code']
@@ -562,8 +562,8 @@ def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=N
     return {"message": f"No {file_type} found for id: {id}, try using the other endpoint"}, 404
 
 
-def _verify_genomic_drs_object(id_):
-    # get the listed samples that the GenomicDrsObject says should be in the file
+def _verify_analysis_drs_object(id_):
+    # get the listed samples that the AnalysisDrsObject says should be in the file
     gen_drs_obj = database.get_drs_object(id_)
     if gen_drs_obj is None:
         raise Exception(f"Could not find object {id_}")
@@ -576,30 +576,30 @@ def _verify_genomic_drs_object(id_):
             if c["id"] in ["variant", "read"]:
                 file_type = c["id"]
     else:
-        raise Exception(f"Object {id_} is not a GenomicDrsObject")
+        raise Exception(f"Object {id_} is not a AnalysisDrsObject")
     if file_type is None:
-        raise Exception(f"Object {id_} should be a GenomicDrsObject, but does not link to a variant or read file")
+        raise Exception(f"Object {id_} should be a AnalysisDrsObject, but does not link to a variant or read file")
 
     # get the samples that are in the linked files
-    gen_obj = drs_operations._get_genomic_obj(id_)
+    gen_obj = drs_operations._get_analysis_obj(id_)
     if gen_obj is None:
-        raise Exception(f"No genomic object with id {id_} exists")
+        raise Exception(f"No analysis object with id {id_} exists")
     if "message" in gen_obj:
         raise Exception(f"{gen_obj['message']}")
     if file_type == "variant":
         # for variant files, we can test whether the linked file is readable by querying it for its samples.
         file_samples = set(gen_obj['file'].header.samples)
         test = drs_samples.difference(file_samples)
-        # the GenomicDrsObject's listed SamplesContentsObjects should match the samples in the VCF file.
+        # the AnalysisDrsObject's listed SamplesContentsObjects should match the samples in the VCF file.
         if len(test) > 0:
-            raise Exception(f"GenomicDrsObject {id_} lists samples {test} that are not in the linked genomic file")
+            raise Exception(f"AnalysisDrsObject {id_} lists samples {test} that are not in the linked analysis file")
     else:
         # for read files, we can test whether the linked file is readable by checking for references in the header.
         try:
             if len(gen_obj['file'].header.references) == 0:
-                raise Exception(f"GenomicDrsObject {id_} links to a read file with no reference sequences")
+                raise Exception(f"AnalysisDrsObject {id_} links to a read file with no reference sequences")
         except Exception as e:
-            raise Exception(f"GenomicDrsObject {id_} links to a read file that could not be read: {str(e)}")
+            raise Exception(f"AnalysisDrsObject {id_} links to a read file that could not be read: {str(e)}")
         if len(drs_samples) > 1:
-            raise Exception(f"GenomicDrsObject {id_} lists multiple samples, but only one can be in the read file")
+            raise Exception(f"AnalysisDrsObject {id_} lists multiple samples, but only one can be in the read file")
     return None

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -33,7 +33,7 @@ def index_variants(file_name=None):
     # calculate_stats(drs_obj_id) Don't calculate checksums, too slow
     logger.info(f"{drs_obj_id} stats done")
 
-    gen_obj = drs_operations._get_genomic_obj(drs_obj_id)
+    gen_obj = drs_operations._get_analysis_obj(drs_obj_id)
     if gen_obj is None:
         return {"message": f"No id {drs_obj_id} exists"}, 404
     if "message" in gen_obj:

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -39,7 +39,7 @@ def find_variants_in_region(reference_name=None, start=None, end=None):
 
 
 def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
-    gen_obj = drs_operations._get_genomic_obj(drs_object_id)
+    gen_obj = drs_operations._get_analysis_obj(drs_object_id)
     if "message" in gen_obj:
         raise Exception(f"error parsing vcf file for {drs_object_id}: {gen_obj['message']}")
     if reference_name is not None:


### PR DESCRIPTION
This is pretty straightforward...the thing that I had been calling a GenomicDrsObject maps cleanly onto the AnalysisDrsObject in the MoHCCN sequencing metadata schema.