### PR TITLE
DIG-1924: Rename SampleDrsObject to ExperimentDrsObject

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -297,14 +297,14 @@ def search(raw_req):
         response['beaconHandovers'] = []
         query_info = {} # program_id and submitter_sample_id
         for drs_obj_id in variants_by_file.keys():
-            # look for samples and programs for all drs objects, even if user is not authorized
+            # look for experiments and programs for all drs objects, even if user is not authorized
             drs_obj = database.get_drs_object(drs_obj_id)
             if "program" in drs_obj:
                 if drs_obj["program"] not in query_info:
                     query_info[drs_obj["program"]] = []
                 for c in drs_obj["contents"]:
                     if c["id"] not in ["variant", "read", "index"]:
-                        # this is a SampleContentObject
+                        # this is a ExperimentContentObject
                         if c["name"] not in query_info[drs_obj["program"]]:
                             query_info[drs_obj["program"]].append(c["name"])
 

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -180,6 +180,7 @@ class PositionBucket(ObjectDBBase):
         return json.dumps(result)
 
 
+# these are samples in variantfiles
 class Sample(ObjectDBBase):
     __tablename__ = 'sample'
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -773,16 +774,6 @@ def list_samples():
             new_obj = json.loads(str(result))
             return new_obj
         return None
-
-
-def get_samples_in_drs_objects(obj):
-    # obj = {'drs_object_ids'}
-    with Session() as session:
-        result = []
-        q = select(Sample.sample_id).where(Sample.variantfile_id.in_(set(obj['drs_object_ids']))).distinct()
-        for row in session.execute(q):
-            result.append(str(row._mapping['sample_id']))
-        return result
 
 
 def get_headers(obj):

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -509,7 +509,7 @@ def delete_drs_object(obj_id, tries=1):
         with Session() as session:
             new_object = session.query(DrsObject).filter_by(id=obj_id).one()
             program = session.query(Program).filter_by(id=new_object.program_id).one_or_none()
-            if new_object.description in ["wgs", "wts"]:
+            if new_object.description in ["variant"]:
                 # this is a AnalysisDrsObject; we need to delete any indexed variantfiles
                 variantfiles = session.query(VariantFile).filter_by(drs_object_id=new_object.id).all()
                 for vf in variantfiles:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -44,7 +44,7 @@ paths:
                 type: array
                 items:
                   anyOf:
-                    - $ref: '#/components/schemas/SampleDrsObject'
+                    - $ref: '#/components/schemas/ExperimentDrsObject'
                     - $ref: '#/components/schemas/AnalysisDrsObject'
                     - $ref: '#/components/schemas/AnalysisDataDrsObject'
                     - $ref: '#/components/schemas/AnalysisIndexDrsObject'
@@ -265,7 +265,7 @@ components:
         'application/json':
           schema:
             anyOf:
-              - $ref: "#/components/schemas/SampleDrsObject"
+              - $ref: "#/components/schemas/ExperimentDrsObject"
               - $ref: "#/components/schemas/AnalysisDrsObject"
               - $ref: "#/components/schemas/AnalysisDataDrsObject"
               - $ref: "#/components/schemas/AnalysisIndexDrsObject"
@@ -316,9 +316,9 @@ components:
     DrsUri:
       type: string
       description: a DRS object's self_uri
-    SampleDrsObject:
+    ExperimentDrsObject:
       type: object
-      description: A DrsObject that describes the clinical sample used for sequencing.
+      description: A DrsObject that describes the sequencing experiment.
       required:
         - id
         - contents
@@ -331,7 +331,7 @@ components:
       properties:
         id:
           type: string
-          description: The identifier for the sample, as defined in sample_registration in the MOHCCN data model.
+          description: The identifier for the experiment, as defined in sample_registration in the MOHCCN data model.
         self_uri:
           type: string
           description: |-
@@ -384,14 +384,14 @@ components:
             = f7a29a04
         contents:
           type: array
-          description: The specific analysis contents objects that were generated from this sample.
+          description: The specific analysis contents objects that were generated from this experiment.
           minItems: 1
           items:
             $ref: '#/components/schemas/AnalysisContentsObject'
         description:
           type: string
           enum:
-            - sample
+            - experiment
         program:
           type: string
           description: The program this object was ingested as part of
@@ -406,7 +406,7 @@ components:
             accession numbers or external GUIDs.
     AnalysisDrsObject:
       type: object
-      description: A DrsObject that describes a sequencing analysis. It usually will consist of a data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Samples (as SampleContentObjects), ordered in order of appearance in the associated variant/read files.
+      description: A DrsObject that describes a sequencing analysis. It usually will consist of a data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Experiments (as ExperimentContentObjects), ordered in order of appearance in the associated variant/read files.
       required:
         - id
         - contents
@@ -428,13 +428,13 @@ components:
             This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
         contents:
           type: array
-          description: The specific analysis contents objects that comprise this analysis DRS entity. Should contain a AnalysisDataContentsObject, an optional AnalysisIndexContentsObject, and SampleContentsObjects corresponding to the samples analyzed in the analysis data object.
+          description: The specific analysis contents objects that comprise this analysis DRS entity. Should contain a AnalysisDataContentsObject, an optional AnalysisIndexContentsObject, and ExperimentContentsObjects corresponding to the experiments analyzed in the analysis data object.
           minItems: 1
           items:
             anyOf:
               - $ref: '#/components/schemas/AnalysisDataContentsObject'
               - $ref: '#/components/schemas/AnalysisIndexContentsObject'
-              - $ref: '#/components/schemas/SampleContentsObject'
+              - $ref: '#/components/schemas/ExperimentContentsObject'
         description:
           type: string
           description: type of sequencing analysis
@@ -787,7 +787,7 @@ components:
           description: The DRS uri(s) to the AnalysisDrsObject
           items:
             type: string
-    SampleContentsObject:
+    ExperimentContentsObject:
       type: object
       required:
         - name
@@ -795,13 +795,13 @@ components:
       properties:
         name:
           type: string
-          description: The submitter_sample_id of the sample in the MoH model
+          description: The submitter_sample_id of the experiment in the MoH model
         id:
           type: string
-          description: The id of the SampleDrsObject, corresponding to the sample's name in the VCF file
+          description: The id of the ExperimentDrsObject, corresponding to the sample's name in the VCF file
         drs_uri:
           type: array
-          description: The DRS uri(s) to the SampleDrsObject
+          description: The DRS uri(s) to the ExperimentDrsObject
           items:
             type: string
     AnalysisDataContentsObject:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -441,9 +441,9 @@ components:
           type: string
           description: type of sequencing analysis
           enum:
-            - wgs
-            - wts
-            - downstream
+            - variant
+            - read
+            - transcript
         program:
           type: string
           description: The program this object was ingested as part of

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -390,8 +390,10 @@ components:
             $ref: '#/components/schemas/AnalysisContentsObject'
         description:
           type: string
+          description: the library strategy used in this experiment
           enum:
-            - experiment
+            - wgs
+            - wts
         program:
           type: string
           description: The program this object was ingested as part of

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -187,7 +187,7 @@ def get_program_status(program_id):
 
 
 # This is specific to our particular use case: a DRS object that represents a
-# particular sample can have a variant or read file and an associated index file.
+# particular experiment can have a variant or read file and an associated index file.
 # We need to query DRS to get the bundling object, which should contain links to
 # two contents objects.
 def _get_analysis_obj(object_id):
@@ -204,8 +204,11 @@ def _get_analysis_obj(object_id):
         if 'message' in main_result:
             result = main_result
         else:
+            ## this is for migration: experiments used to be samples
             if "samples" in drs_obj:
-                result['samples'] = drs_obj['samples']
+                result['experiments'] = drs_obj['samples']
+            elif "experiments" in drs_obj:
+                result['experiments'] = drs_obj['experiments']
             try:
                 result['file_format'] = drs_obj['format']
                 if drs_obj['type'] == 'read':
@@ -225,7 +228,7 @@ def _describe_drs_object(object_id):
     result = {
         "name": object_id
     }
-    # drs_obj should have a main contents, index contents, and sample contents
+    # drs_obj should have a main contents, index contents, and experiment contents
     if "contents" in drs_obj:
         for contents in drs_obj["contents"]:
             # get each drs object (should be the analysis file and its index)
@@ -249,9 +252,12 @@ def _describe_drs_object(object_id):
             elif index_match is not None:
                 result['index'] = contents['name']
             else:
-                if "samples" not in result:
-                    result['samples'] = {}
-                result['samples'][contents['id']] = contents['name']
+                ## this is for migration: experiments used to be samples
+                if "samples" in result:
+                    result["experiments"] = result["samples"]
+                if "experiments" not in result:
+                    result['experiments'] = {}
+                result['experiments'][contents['id']] = contents['name']
 
     if 'type' not in result:
         return {"message": f"drs object {object_id} does not represent an htsget object", "status_code": 404}

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -421,11 +421,11 @@ paths:
                                 type: object
                                 $ref: '#/components/schemas/GeneSearchResultsTicket'
 
-    /samples/{id}:
+    /experiments/{id}:
         get:
-            summary: Get metadata about a sample
-            operationId: htsget_operations.get_sample
-            description: Get MoH-relevant genomic information about a sample
+            summary: Get metadata about a experiment
+            operationId: htsget_operations.get_experiment
+            description: Get MoH-relevant genomic information about an experiment
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
                 - $ref: "#/components/parameters/idPathParam"
@@ -435,12 +435,12 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/SampleTicket'
-    /samples:
+                                $ref: '#/components/schemas/ExperimentTicket'
+    /experiments:
         get:
-            summary: Get metadata about samples in a program
-            operationId: htsget_operations.get_program_samples
-            description: Get MoH-relevant genomic information about all samples in a program
+            summary: Get metadata about experiments in a program
+            operationId: htsget_operations.get_program_experiments
+            description: Get MoH-relevant genomic information about all experiments in a program
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
                 - $ref: '#/components/parameters/programParam'
@@ -452,15 +452,15 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/SampleTicket'
+                                    $ref: '#/components/schemas/ExperimentTicket'
         post:
-            summary: Get metadata about multiple samples
-            operationId: htsget_operations.get_multiple_samples
-            description: Get MoH-relevant genomic information about a list of samples
+            summary: Get metadata about multiple experiments
+            operationId: htsget_operations.get_multiple_experiments
+            description: Get MoH-relevant genomic information about a list of experiments
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
             requestBody:
-                $ref: '#/components/requestBodies/SamplesRequestBody'
+                $ref: '#/components/requestBodies/ExperimentsRequestBody'
             responses:
                 200:
                     description: Success
@@ -469,7 +469,7 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/SampleTicket'
+                                    $ref: '#/components/schemas/ExperimentTicket'
 
 tags:
     - name: Reads
@@ -707,7 +707,7 @@ components:
               type: array
               items:
                 type: object
-            samples:
+            experiments:
               type: array
               items:
                 type: object
@@ -897,10 +897,10 @@ components:
                                                 - hg38
                                         region:
                                             $ref: '#/components/schemas/Region'
-        SampleTicket:
+        ExperimentTicket:
             type: object
             properties:
-                sample_id:
+                experiment_id:
                     type: string
                     description: MoH submitter_sample_id from a Sample Registration associated with a specimen.
                 program:
@@ -1000,14 +1000,6 @@ components:
             required: false
             schema:
                 $ref: '#/components/schemas/ReferenceGenome'
-        sampleIdPathParam:
-            in: path
-            name: id
-            description: MoH Sample Registration ID for a sample with associated genomic data
-            required: true
-            schema:
-                type: string
-                format: path
         readsFormatParam:
             in: query
             name: format
@@ -1141,15 +1133,15 @@ components:
                 application/json:
                     schema:
                         $ref: '#/components/schemas/ReadsRequestBody'
-        SamplesRequestBody:
-            description: List of samples requested
+        ExperimentsRequestBody:
+            description: List of experiments requested
             required: false
             content:
                 application/json:
                     schema:
                         type: object
                         properties:
-                            samples:
+                            experiments:
                                 type: array
                                 items:
                                     type: string

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -193,8 +193,8 @@ def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
         drs_obj = database.get_drs_object(id_)
         if drs_obj is None:
             return {"message": f"No DRS object exists with ID {id_}"}, 404
-        if drs_obj['description'] not in ['wgs', 'wts']:
-            return {"message": f"DRS object {id_} is not a analysis object"}, 404
+        if drs_obj['description'] not in ['variant']:
+            return {"message": f"DRS object {id_} is not an analysis object: {drs_obj['description']}"}, 404
         program = ""
         if "program" in drs_obj:
             program = drs_obj['program']
@@ -288,7 +288,7 @@ def get_program_experiments(program=None):
         experiment_drs_objs = database.list_drs_objects()
     else:
         experiment_drs_objs = database.list_drs_objects(program)
-    experiments = list(map(lambda y: y["id"], filter(lambda x: x["description"] == "experiment", experiment_drs_objs)))
+    experiments = list(map(lambda y: y["id"], filter(lambda x: x["description"] in ["wgs", "wts"], experiment_drs_objs)))
     result = []
     experiments_by_program = {}
     return _get_experiments(experiments), 200
@@ -320,17 +320,16 @@ def _get_experiment(id_=None):
     }
 
     # Get the ExperimentDrsObject. It will have a contents array of AnalysisContentsObjects > AnalysisDrsObjects.
-    # Each of those AnalysisDrsObjects will have a description that is either 'wgs' or 'wts'.
     experiment_drs_obj = database.get_drs_object(id_)
-    if experiment_drs_obj is not None and "contents" in experiment_drs_obj and experiment_drs_obj["description"] == "experiment":
+    if experiment_drs_obj is not None and "contents" in experiment_drs_obj and experiment_drs_obj["description"] in ["wgs", "wts"]:
+        if experiment_drs_obj["description"] == "wgs":
+            result["genomes"].append(experiment_drs_obj["id"])
+        elif experiment_drs_obj["description"] == "wts":
+            result["transcriptomes"].append(experiment_drs_obj["id"])
         result["program"] = experiment_drs_obj["program"]
         for contents_obj in experiment_drs_obj["contents"]:
             drs_obj = database.get_drs_object(contents_obj["id"])
             if drs_obj is not None:
-                if drs_obj["description"] == "wgs":
-                    result["genomes"].append(drs_obj["id"])
-                elif drs_obj["description"] == "wts":
-                    result["transcriptomes"].append(drs_obj["id"])
                 # check the contents of this analysis drs object and see if it contains variants or reads
                 if "contents" in drs_obj:
                     for content in drs_obj["contents"]:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -270,61 +270,61 @@ def get_matching_transcripts(id_=None):
     return get_matching_genes(id_=id_, type="transcript_name")
 
 
-@app.route('/samples/<path:id_>')
-def get_sample(id_=None):
-    result, status_code = _get_sample(id_)
+@app.route('/experiments/<path:id_>')
+def get_experiment(id_=None):
+    result, status_code = _get_experiment(id_)
     if authz.is_authed(id_, connexion.request):
         return result, 200
-    return {"message": f"Could not find sample {id_}"}, 404
+    return {"message": f"Could not find experiment {id_}"}, 404
 
 
-async def get_multiple_samples():
+async def get_multiple_experiments():
     req = await connexion.request.json()
-    return _get_samples(req["samples"]), 200
+    return _get_experiments(req["experiments"]), 200
 
 
-def get_program_samples(program=None):
+def get_program_experiments(program=None):
     if program is None:
-        sample_drs_objs = database.list_drs_objects()
+        experiment_drs_objs = database.list_drs_objects()
     else:
-        sample_drs_objs = database.list_drs_objects(program)
-    samples = list(map(lambda y: y["id"], filter(lambda x: x["description"] == "sample", sample_drs_objs)))
+        experiment_drs_objs = database.list_drs_objects(program)
+    experiments = list(map(lambda y: y["id"], filter(lambda x: x["description"] == "experiment", experiment_drs_objs)))
     result = []
-    samples_by_program = {}
-    return _get_samples(samples), 200
+    experiments_by_program = {}
+    return _get_experiments(experiments), 200
 
 
-def _get_samples(samples):
+def _get_experiments(experiments):
     result = []
-    samples_by_program = {}
-    for sample in samples:
-        res, status_code = _get_sample(sample)
+    experiments_by_program = {}
+    for experiment in experiments:
+        res, status_code = _get_experiment(experiment)
         if status_code == 200:
-            if res["program"] not in samples_by_program:
-                samples_by_program[res["program"]] = []
-            samples_by_program[res["program"]].append(res)
+            if res["program"] not in experiments_by_program:
+                experiments_by_program[res["program"]] = []
+            experiments_by_program[res["program"]].append(res)
     authz_programs = authz.get_authorized_programs(connexion.request)
     for program in authz_programs:
-        if program in samples_by_program:
-            result.extend(samples_by_program[program])
+        if program in experiments_by_program:
+            result.extend(experiments_by_program[program])
     return result
 
 
-def _get_sample(id_=None):
+def _get_experiment(id_=None):
     result = {
-        "sample_id": id_,
+        "experiment_id": id_,
         "genomes": [],
         "transcriptomes": [],
         "variants": [],
         "reads": []
     }
 
-    # Get the SampleDrsObject. It will have a contents array of AnalysisContentsObjects > AnalysisDrsObjects.
+    # Get the ExperimentDrsObject. It will have a contents array of AnalysisContentsObjects > AnalysisDrsObjects.
     # Each of those AnalysisDrsObjects will have a description that is either 'wgs' or 'wts'.
-    sample_drs_obj = database.get_drs_object(id_)
-    if sample_drs_obj is not None and "contents" in sample_drs_obj and sample_drs_obj["description"] == "sample":
-        result["program"] = sample_drs_obj["program"]
-        for contents_obj in sample_drs_obj["contents"]:
+    experiment_drs_obj = database.get_drs_object(id_)
+    if experiment_drs_obj is not None and "contents" in experiment_drs_obj and experiment_drs_obj["description"] == "experiment":
+        result["program"] = experiment_drs_obj["program"]
+        for contents_obj in experiment_drs_obj["contents"]:
             drs_obj = database.get_drs_object(contents_obj["id"])
             if drs_obj is not None:
                 if drs_obj["description"] == "wgs":
@@ -563,16 +563,16 @@ def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=N
 
 
 def _verify_analysis_drs_object(id_):
-    # get the listed samples that the AnalysisDrsObject says should be in the file
+    # get the listed experiments that the AnalysisDrsObject says should be in the file
     gen_drs_obj = database.get_drs_object(id_)
     if gen_drs_obj is None:
         raise Exception(f"Could not find object {id_}")
-    drs_samples = set()
+    drs_experiments = set()
     file_type = None
     if "contents" in gen_drs_obj and "reference_genome" in gen_drs_obj:
         for c in gen_drs_obj["contents"]:
             if c["id"] not in ["variant", "read", "index"]:
-                drs_samples.add(c["id"])
+                drs_experiments.add(c["id"])
             if c["id"] in ["variant", "read"]:
                 file_type = c["id"]
     else:
@@ -580,19 +580,19 @@ def _verify_analysis_drs_object(id_):
     if file_type is None:
         raise Exception(f"Object {id_} should be a AnalysisDrsObject, but does not link to a variant or read file")
 
-    # get the samples that are in the linked files
+    # get the experiments that are in the linked files
     gen_obj = drs_operations._get_analysis_obj(id_)
     if gen_obj is None:
         raise Exception(f"No analysis object with id {id_} exists")
     if "message" in gen_obj:
         raise Exception(f"{gen_obj['message']}")
     if file_type == "variant":
-        # for variant files, we can test whether the linked file is readable by querying it for its samples.
+        # for variant files, we can test whether the linked file is readable by querying it for its experiments.
         file_samples = set(gen_obj['file'].header.samples)
-        test = drs_samples.difference(file_samples)
-        # the AnalysisDrsObject's listed SamplesContentsObjects should match the samples in the VCF file.
+        test = drs_experiments.difference(file_samples)
+        # the AnalysisDrsObject's listed ExperimentContentsObjects should match the samples in the VCF file.
         if len(test) > 0:
-            raise Exception(f"AnalysisDrsObject {id_} lists samples {test} that are not in the linked analysis file")
+            raise Exception(f"AnalysisDrsObject {id_} lists experiments {test} that are not in the linked analysis file")
     else:
         # for read files, we can test whether the linked file is readable by checking for references in the header.
         try:
@@ -600,6 +600,6 @@ def _verify_analysis_drs_object(id_):
                 raise Exception(f"AnalysisDrsObject {id_} links to a read file with no reference sequences")
         except Exception as e:
             raise Exception(f"AnalysisDrsObject {id_} links to a read file that could not be read: {str(e)}")
-        if len(drs_samples) > 1:
-            raise Exception(f"AnalysisDrsObject {id_} lists multiple samples, but only one can be in the read file")
+        if len(drs_experiments) > 1:
+            raise Exception(f"AnalysisDrsObject {id_} lists multiple experiments, but only one can be in the read file")
     return None

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -39,14 +39,14 @@ def find_variants_in_region(reference_name=None, start=None, end=None):
 
 
 def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
-    gen_obj = drs_operations._get_analysis_obj(drs_object_id)
-    if "message" in gen_obj:
-        raise Exception(f"error parsing vcf file for {drs_object_id}: {gen_obj['message']}")
+    analysis_obj = drs_operations._get_analysis_obj(drs_object_id)
+    if "message" in analysis_obj:
+        raise Exception(f"error parsing vcf file for {drs_object_id}: {analysis_obj['message']}")
     if reference_name is not None:
         ref_name = database.get_contig_name_in_variantfile({'refname': reference_name, 'variantfile_id': drs_object_id})
-        records = gen_obj['file'].fetch(contig=ref_name, start=start, end=end)
+        records = analysis_obj['file'].fetch(contig=ref_name, start=start, end=end)
     else:
-        records = gen_obj['file'].fetch()
+        records = analysis_obj['file'].fetch()
     headers = parse_headers(database.get_headers({'variantfile_id': drs_object_id}))
 
     variants_by_file = {
@@ -69,13 +69,15 @@ def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
     if 'contig' in headers:
         variants_by_file['contig'] = headers.pop('contig')
     for r in records:
-        samples = []
-        for s in r.samples:
-            if "samples" in gen_obj and s in gen_obj['samples']:
-                samples.append(gen_obj['samples'][s])
+        experiments = []
+        for vcf_sample in r.samples:
+            # experiments in analysis_obj are listed as {vcf_sample: experiment_id}
+            if "experiments" in analysis_obj and vcf_sample in analysis_obj['experiments']:
+                experiment_id = analysis_obj['experiments'][vcf_sample]
+                experiments.append(experiment_id)
             else:
-                samples.append(s)
-        variant_record = parse_variant_record(str(r), samples, variants_by_file['info'])
+                experiments.append(vcf_sample)
+        variant_record = parse_variant_record(str(r), experiments, variants_by_file['info'])
         variants_by_file['variants'].append(variant_record)
     return variants_by_file
 

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -280,13 +280,13 @@ def test_add_sample_drs(input, program_id):
     post_url = f"{HOST}/ga4gh/drs/v1/objects"
     headers = get_headers()
 
-    # look for the main genomic drs object
+    # look for the main analysis drs object
     get_url = f"{HOST}/ga4gh/drs/v1/objects/{input['genomic_id']}"
     response = requests.request("GET", get_url, headers=headers)
     if response.status_code == 200:
         assert response.status_code == 200
-    genomic_drs_obj = response.json()
-    contents_count = len(genomic_drs_obj["contents"])
+    analysis_drs_obj = response.json()
+    contents_count = len(analysis_drs_obj["contents"])
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
     for sample in input['samples']:
@@ -319,7 +319,7 @@ def test_add_sample_drs(input, program_id):
         print(f"POST {experiment_drs_object['id']}: {response.text}")
         assert response.status_code == 200
 
-        # add the experiment contents to the genomic_drs_object's contents
+        # add the experiment contents to the analysis_drs_object's contents
         experiment_contents = {
             "drs_uri": [
                 f"{drs_url}/{sample_id}"
@@ -327,14 +327,14 @@ def test_add_sample_drs(input, program_id):
             "name": sample_id,
             "id": sample['sample_name_in_file']
         }
-        genomic_drs_obj["contents"].append(experiment_contents)
+        analysis_drs_obj["contents"].append(experiment_contents)
 
-    response = requests.post(post_url, json=genomic_drs_obj, headers=get_headers())
+    response = requests.post(post_url, json=analysis_drs_obj, headers=get_headers())
     print(response.text)
     response = requests.request("GET", get_url, headers=get_headers())
     if response.status_code == 200:
         assert response.status_code == 200
-    assert len(genomic_drs_obj["contents"]) == contents_count + 1
+    assert len(analysis_drs_obj["contents"]) == contents_count + 1
 
     verify_url = f"{HOST}/htsget/v1/variants/{input['genomic_id']}/verify"
     response = requests.get(verify_url, headers=get_headers())
@@ -614,7 +614,7 @@ def drs_objects():
             "version": "v1",
             "program": "test-htsget"
         })
-        # add it to the contents of the genomic_drs_obj:
+        # add it to the contents of the analysis_drs_obj:
         analysis_drs_obj['contents'].append({
             "drs_uri": [
                 f"{drs_url}/{index_file}"
@@ -632,7 +632,7 @@ def drs_objects():
             "version": "v1",
             "program": "test-htsget"
         })
-        # add it to the contents of the genomic_drs_obj:
+        # add it to the contents of the analysis_drs_obj:
         analysis_drs_obj['contents'].append({
             "drs_uri": [
                 f"{drs_url}/{data_file}"

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -302,7 +302,7 @@ def test_add_sample_drs(input, program_id):
         # create a experimentdrsobject to correspond to each sample:
         experiment_drs_object = {
             "id": sample_id,
-            "description": "sample",
+            "description": "experiment",
             "contents": [
                 {
                     "drs_uri": [

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -189,7 +189,7 @@ def test_install_public_object():
                 "id": "index"
               }
             ],
-            "description": "wgs",
+            "description": "variant",
             "reference_genome": "hg38",
             "id": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes",
             "mime_type": "application/octet-stream",
@@ -265,18 +265,18 @@ def get_ingest_file():
     ]
 
 
-def get_ingest_sample_names(genomic_id):
+def get_ingest_experiment_names(genomic_id):
     result = {}
     for item in get_ingest_file():
         ingest_map, program_id = item
         if ingest_map["genomic_id"] == genomic_id:
             for sample in ingest_map["samples"]:
-                result[sample['sample_name_in_file']] = f"{sample['sample_registration_id']}"
+                result[sample['sample_registration_id']] = f"{sample['sample_name_in_file']}"
     return result
 
 
 @pytest.mark.parametrize('input, program_id', get_ingest_file())
-def test_add_sample_drs(input, program_id):
+def test_add_experiment_drs(input, program_id):
     post_url = f"{HOST}/ga4gh/drs/v1/objects"
     headers = get_headers()
 
@@ -289,26 +289,26 @@ def test_add_sample_drs(input, program_id):
     contents_count = len(analysis_drs_obj["contents"])
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
-    for sample in input['samples']:
-        sample_id = f"{sample['sample_registration_id']}"
+    for experiment in input['samples']:
+        experiment_id = f"{experiment['sample_registration_id']}"
         # remove any existing objects:
-        sample_url = f"{HOST}/ga4gh/drs/v1/objects/{sample_id}"
-        response = requests.request("GET", sample_url, headers=headers)
+        experiment_url = f"{HOST}/ga4gh/drs/v1/objects/{experiment_id}"
+        response = requests.request("GET", experiment_url, headers=headers)
         if response.status_code == 200:
-            response = requests.request("DELETE", sample_url, headers=headers)
-            print(f"DELETE {sample_id}: {response.text}")
+            response = requests.request("DELETE", experiment_url, headers=headers)
+            print(f"DELETE {experiment_id}: {response.text}")
             assert response.status_code == 200
 
-        # create a experimentdrsobject to correspond to each sample:
+        # create a experimentdrsobject to correspond to each experiment:
         experiment_drs_object = {
-            "id": sample_id,
+            "id": experiment_id,
             "description": "wgs",
             "contents": [
                 {
                     "drs_uri": [
                         f"{drs_url}/{input['genomic_id']}"
                     ],
-                    "name": sample['sample_name_in_file'],
+                    "name": experiment['sample_name_in_file'],
                     "id": input['genomic_id']
                 }
             ],
@@ -322,10 +322,10 @@ def test_add_sample_drs(input, program_id):
         # add the experiment contents to the analysis_drs_object's contents
         experiment_contents = {
             "drs_uri": [
-                f"{drs_url}/{sample_id}"
+                f"{drs_url}/{experiment_id}"
             ],
-            "name": sample_id,
-            "id": sample['sample_name_in_file']
+            "name": experiment_id,
+            "id": experiment['sample_name_in_file']
         }
         analysis_drs_obj["contents"].append(experiment_contents)
 
@@ -343,20 +343,21 @@ def test_add_sample_drs(input, program_id):
 
 
 @pytest.mark.parametrize('input, program_id', get_ingest_file())
-def test_sample_stats(input, program_id):
+def test_experiment_stats(input, program_id):
     headers = get_headers()
 
-    sample = get_ingest_sample_names(input['genomic_id'])
-    print(sample)
-    # look for the sample
-    get_url = f"{HOST}/htsget/v1/experiments/{sample[list(sample.keys()).pop()]}"
+    experiments = get_ingest_experiment_names(input['genomic_id'])
+    experiment = list(experiments.keys()).pop()
+    # look for the experiment
+    get_url = f"{HOST}/htsget/v1/experiments/{experiment}"
     response = requests.request("GET", get_url, headers=headers)
     assert response.status_code == 200
 
-    assert input['genomic_id'] in response.json()['genomes']
+    # genomes in a program will be experiments, which are listed by sample_registration_id
+    assert experiment in response.json()['genomes']
 
 
-def test_program_samples():
+def test_program_experiments():
     headers = get_headers()
 
     get_url = f"{HOST}/htsget/v1/experiments"

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -302,7 +302,7 @@ def test_add_sample_drs(input, program_id):
         # create a experimentdrsobject to correspond to each sample:
         experiment_drs_object = {
             "id": sample_id,
-            "description": "experiment",
+            "description": "wgs",
             "contents": [
                 {
                     "drs_uri": [
@@ -596,7 +596,7 @@ def drs_objects():
         # make a analysisdrsobj:
         analysis_drs_obj = {
             "id": drs_obj,
-            "description": "wgs",
+            "description": type,
             "mime_type": "application/octet-stream",
             "name": drs_obj,
             "contents": [],

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -589,8 +589,12 @@ def drs_objects():
     result = []
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
     for drs_obj in drs_objects:
-        # make a genomicdrsobj:
-        genomic_drs_obj = {
+        index_file = drs_objects[drs_obj].pop("index")
+        type = list(drs_objects[drs_obj].keys()).pop()
+        data_file = drs_objects[drs_obj].pop(type)
+
+        # make a analysisdrsobj:
+        analysis_drs_obj = {
             "id": drs_obj,
             "description": "wgs",
             "mime_type": "application/octet-stream",
@@ -600,10 +604,8 @@ def drs_objects():
             "reference_genome": "hg38",
             "program": "test-htsget"
         }
-        result.append(genomic_drs_obj)
+        result.append(analysis_drs_obj)
 
-        # make a genomicindexdrsobj:
-        index_file = drs_objects[drs_obj].pop("index")
         result.append({
             "id": index_file,
             "description": "index",
@@ -613,7 +615,7 @@ def drs_objects():
             "program": "test-htsget"
         })
         # add it to the contents of the genomic_drs_obj:
-        genomic_drs_obj['contents'].append({
+        analysis_drs_obj['contents'].append({
             "drs_uri": [
                 f"{drs_url}/{index_file}"
             ],
@@ -621,9 +623,7 @@ def drs_objects():
             "id": "index"
         })
 
-        # make a genomicdatadrsobj:
-        type = list(drs_objects[drs_obj].keys()).pop()
-        data_file = drs_objects[drs_obj].pop(type)
+        # make a analysisdatadrsobj:
         result.append({
             "id": data_file,
             "description": type,
@@ -633,7 +633,7 @@ def drs_objects():
             "program": "test-htsget"
         })
         # add it to the contents of the genomic_drs_obj:
-        genomic_drs_obj['contents'].append({
+        analysis_drs_obj['contents'].append({
             "drs_uri": [
                 f"{drs_url}/{data_file}"
             ],

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -299,8 +299,8 @@ def test_add_sample_drs(input, program_id):
             print(f"DELETE {sample_id}: {response.text}")
             assert response.status_code == 200
 
-        # create a sampledrsobject to correspond to each sample:
-        sample_drs_object = {
+        # create a experimentdrsobject to correspond to each sample:
+        experiment_drs_object = {
             "id": sample_id,
             "description": "sample",
             "contents": [
@@ -315,19 +315,19 @@ def test_add_sample_drs(input, program_id):
             "version": "v1",
             "program": program_id
         }
-        response = requests.request("POST", post_url, json=sample_drs_object, headers=headers)
-        print(f"POST {sample_drs_object['id']}: {response.text}")
+        response = requests.request("POST", post_url, json=experiment_drs_object, headers=headers)
+        print(f"POST {experiment_drs_object['id']}: {response.text}")
         assert response.status_code == 200
 
-        # add the sample contents to the genomic_drs_object's contents
-        sample_contents = {
+        # add the experiment contents to the genomic_drs_object's contents
+        experiment_contents = {
             "drs_uri": [
                 f"{drs_url}/{sample_id}"
             ],
             "name": sample_id,
             "id": sample['sample_name_in_file']
         }
-        genomic_drs_obj["contents"].append(sample_contents)
+        genomic_drs_obj["contents"].append(experiment_contents)
 
     response = requests.post(post_url, json=genomic_drs_obj, headers=get_headers())
     print(response.text)
@@ -349,7 +349,7 @@ def test_sample_stats(input, program_id):
     sample = get_ingest_sample_names(input['genomic_id'])
     print(sample)
     # look for the sample
-    get_url = f"{HOST}/htsget/v1/samples/{sample[list(sample.keys()).pop()]}"
+    get_url = f"{HOST}/htsget/v1/experiments/{sample[list(sample.keys()).pop()]}"
     response = requests.request("GET", get_url, headers=headers)
     assert response.status_code == 200
 
@@ -359,7 +359,7 @@ def test_sample_stats(input, program_id):
 def test_program_samples():
     headers = get_headers()
 
-    get_url = f"{HOST}/htsget/v1/samples"
+    get_url = f"{HOST}/htsget/v1/experiments"
     response = requests.request("GET", get_url, headers=headers)
     print(response.json())
     response = requests.request("GET", get_url, headers=headers, params={"program": "1000genomes"})


### PR DESCRIPTION
(dangit, I messed up and closed the original PR by deleting the base branch)

I've based this on the daisieh/analysis branch to make the code review more clear, but I will merge this to develop in the end. This one is somewhat confusing to look through, because the samples that are equivalent to experiments are the ones that are referring to SampleRegistrations in the MOHCCN data model, but not the ones that are called samples in vcf files. So the database refers to a Sample object, but that is a vcf sample, not an experiment sample.

These changes (along with some tweaks to candig-ingest and integration tests) pass tests on CanDIGv2 overall.