### PR TITLE
DIG-1922: sequencing metadata MVP

### DIFF
--- a/create_db.sh
+++ b/create_db.sh
@@ -43,4 +43,5 @@ psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_288.sql >>setup_out.tx
 psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_315.sql >>setup_out.txt
 psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_339.sql >>setup_out.txt
 psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_341.sql >>setup_out.txt
+psql --quiet -h "$db" -U $PGUSER -d genomic -a -f data/pr_352.sql >>setup_out.txt
 echo "...done"

--- a/data/files.sql
+++ b/data/files.sql
@@ -17,6 +17,7 @@ CREATE TABLE drs_object (
         description VARCHAR,
         aliases VARCHAR,
         program_id VARCHAR,
+		meta_data JSONB,
         PRIMARY KEY (id),
         FOREIGN KEY(program_id) REFERENCES program (id)
 );

--- a/data/files.sql
+++ b/data/files.sql
@@ -17,7 +17,7 @@ CREATE TABLE drs_object (
         description VARCHAR,
         aliases VARCHAR,
         program_id VARCHAR,
-		meta_data JSONB,
+        meta_data JSONB,
         PRIMARY KEY (id),
         FOREIGN KEY(program_id) REFERENCES program (id)
 );

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -285,6 +285,7 @@ class DrsObject(ObjectDBBase):
     program_id = Column(String, ForeignKey('program.id'))
     program = relationship("Program", back_populates="associated_drs")
     variantfile = relationship("VariantFile", back_populates="drs_object", cascade="all, delete")
+    meta_data = Column(JSON)
 
     def __repr__(self):
         result = {
@@ -311,6 +312,10 @@ class DrsObject(ObjectDBBase):
         if self.variantfile is not None and len(self.variantfile) > 0:
             result['indexed'] = self.variantfile[0].indexed
             result['reference_genome'] = self.variantfile[0].reference_genome
+        if self.metadata is not None:
+            result['metadata'] = self.meta_data
+        else:
+            result['metadata'] = {}
         return json.dumps(result)
 
 
@@ -434,6 +439,8 @@ def create_drs_object(obj, tries=1):
                 new_object.size = obj['size']
             if 'description' in obj:
                 new_object.description = obj['description']
+            if 'metadata' in obj:
+                new_object.meta_data = obj['metadata']
             if 'program' in obj:
                 program = session.query(Program).filter_by(id=obj['program']).one_or_none()
                 if program is None:

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -302,6 +302,8 @@ class DrsObject(ObjectDBBase):
         }
         if len(list(self.contents)) > 0:
             result['contents'] = json.loads(self.contents.__repr__())
+        else:
+            result['contents'] = []
         if len(list(self.access_methods)) > 0:
             result['access_methods'] = json.loads(self.access_methods.__repr__())
         if self.program is not None:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -321,6 +321,7 @@ components:
       description: A DrsObject that describes the sequencing experiment.
       required:
         - id
+        - name
         - contents
         - description
         - program
@@ -329,9 +330,12 @@ components:
 #        - created_time
 #        - checksums
       properties:
+        name:
+          type: string
+          description: The specimen identifier for the experiment, as defined in sample_registration in the MOHCCN data model.
         id:
           type: string
-          description: The identifier for the experiment, as defined in sample_registration in the MOHCCN data model.
+          description: The alias for the experiment, as defined by the sequencing center
         self_uri:
           type: string
           description: |-
@@ -385,7 +389,6 @@ components:
         contents:
           type: array
           description: The specific analysis contents objects that were generated from this experiment.
-          minItems: 1
           items:
             $ref: '#/components/schemas/AnalysisContentsObject'
         description:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -446,10 +446,6 @@ components:
         description:
           type: string
           description: type of sequencing analysis
-          enum:
-            - variant
-            - read
-            - transcript
         program:
           type: string
           description: The program this object was ingested as part of
@@ -554,10 +550,6 @@ components:
             The list of access methods that can be used to fetch the `DrsObject`.
         description:
           type: string
-          enum:
-            - variant
-            - read
-            - transcript
         program:
             type: string
             description: The program this object was ingested as part of

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -409,6 +409,9 @@ components:
             about this `DrsObject` from external metadata sources. These
             aliases can be used to represent secondary
             accession numbers or external GUIDs.
+        metadata:
+          type: object
+          description: metadata about the experiment (see Experiment in ingest_openapi.yaml)
     AnalysisDrsObject:
       type: object
       description: A DrsObject that describes a sequencing analysis. It usually will consist of a data file, e.g. a variant or read file, and its associated index file. Its contents should also include any associated Experiments (as ExperimentContentObjects), ordered in order of appearance in the associated variant/read files.
@@ -518,6 +521,9 @@ components:
             = md5( concat( 5e089d29, 72794b6d ) )
             = md5( 5e089d2972794b6d )
             = f7a29a04
+        metadata:
+          type: object
+          description: metadata about the analysis (see Analysis in ingest_openapi.yaml)
     AnalysisDataDrsObject:
       type: object
       description: A DrsObject that describes a analysis data file, e.g. a variant or read file.

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -226,7 +226,8 @@ def _describe_drs_object(object_id):
     if drs_obj is None:
         return None
     result = {
-        "name": object_id
+        "name": object_id,
+        "program": drs_obj["program"]
     }
     # drs_obj should have a main contents, index contents, and experiment contents
     if "contents" in drs_obj:

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -281,7 +281,6 @@ paths:
             parameters:
                 - $ref: '#/components/parameters/idPathParam'
                 - $ref: '#/components/parameters/forceParam'
-                - $ref: '#/components/parameters/doNotIndexParam'
                 - $ref: '#/components/parameters/refGenomeParam'
             responses:
                 200:
@@ -933,13 +932,6 @@ components:
             in: query
             name: force
             description: force indexing
-            required: false
-            schema:
-                type: boolean
-        doNotIndexParam:
-            in: query
-            name: do_not_index
-            description: do not index
             required: false
             schema:
                 type: boolean

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -158,53 +158,6 @@ paths:
                5XX:
                    $ref: '#/components/responses/5xxServerError'
 
-    /reads/{id}/index:
-      get:
-          tags:
-              - Reads
-          summary: Calculate size and checksums for the read object
-          operationId: "htsget_operations.index_reads"
-          description: Calculate size and checksums for the read object
-          parameters:
-              - $ref: '#/components/parameters/idPathParam'
-          responses:
-              200:
-                  description: Read file queued for indexing
-                  content:
-                      application/json:
-                          schema:
-                              type: object
-              400:
-                  $ref: '#/components/responses/400BadRequestError'
-              404:
-                  $ref: '#/components/responses/404NotFoundError'
-              5XX:
-                  $ref: '#/components/responses/5xxServerError'
-
-    /reads/{id}/verify:
-       get:
-           tags:
-               - Reads
-           summary: Verify the integrity of the read object
-           operationId: "htsget_operations.verify_reads_analysis_drs_object"
-           description: |
-               Verify the integrity of the read object
-           parameters:
-               - $ref: '#/components/parameters/idPathParam'
-           responses:
-               200:
-                   description: Read file stored correctly
-                   content:
-                       application/json:
-                           schema:
-                               type: object
-               400:
-                   $ref: '#/components/responses/400BadRequestError'
-               404:
-                   $ref: '#/components/responses/404NotFoundError'
-               5XX:
-                   $ref: '#/components/responses/5xxServerError'
-
     /variants/service-info:
        get:
            tags:
@@ -257,57 +210,6 @@ paths:
                 5XX:
                     $ref: '#/components/responses/5xxServerError'
 
-    /variants/{id}/index:
-        get:
-            tags:
-                - Variants
-            summary: Index variant file for search
-            operationId: "htsget_operations.index_variants"
-            description: |
-                Index a variant file for searching
-            parameters:
-                - $ref: '#/components/parameters/idPathParam'
-                - $ref: '#/components/parameters/forceParam'
-                - $ref: '#/components/parameters/doNotIndexParam'
-                - $ref: '#/components/parameters/refGenomeParam'
-            responses:
-                200:
-                    description: Variant file queued for indexing
-                    content:
-                        application/json:
-                            schema:
-                                type: object
-                400:
-                    $ref: '#/components/responses/400BadRequestError'
-                404:
-                    $ref: '#/components/responses/404NotFoundError'
-                5XX:
-                    $ref: '#/components/responses/5xxServerError'
-
-    /variants/{id}/verify:
-        get:
-            tags:
-                - Variants
-            summary: Verify the integrity of the variant object
-            operationId: "htsget_operations.verify_variants_analysis_drs_object"
-            description: |
-                Verify the integrity of the variant object
-            parameters:
-                - $ref: '#/components/parameters/idPathParam'
-            responses:
-                200:
-                    description: Variant file stored correctly
-                    content:
-                        application/json:
-                            schema:
-                                type: object
-                400:
-                    $ref: '#/components/responses/400BadRequestError'
-                404:
-                    $ref: '#/components/responses/404NotFoundError'
-                5XX:
-                    $ref: '#/components/responses/5xxServerError'
-
     /variants/data/{id}:
         get:
             tags:
@@ -347,6 +249,54 @@ paths:
                     $ref: '#/components/responses/404NotFoundError'
                 5XX:
                     $ref: '#/components/responses/5xxServerError'
+
+## analysis processing methods
+    /{id}/verify:
+        get:
+            summary: Verify the integrity of the  object
+            operationId: "htsget_operations.verify_analysis_drs_object"
+            description: |
+                Verify the integrity of the analysis object
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+            responses:
+                200:
+                    description: file stored correctly
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5XX:
+                    $ref: '#/components/responses/5xxServerError'
+    /{id}/index:
+        get:
+            summary: Index variant file for search
+            operationId: "htsget_operations.index_analysis"
+            description: |
+                Index an analysis for searching
+            parameters:
+                - $ref: '#/components/parameters/idPathParam'
+                - $ref: '#/components/parameters/forceParam'
+                - $ref: '#/components/parameters/doNotIndexParam'
+                - $ref: '#/components/parameters/refGenomeParam'
+            responses:
+                200:
+                    description: Analysis queued for indexing
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                400:
+                    $ref: '#/components/responses/400BadRequestError'
+                404:
+                    $ref: '#/components/responses/404NotFoundError'
+                5XX:
+                    $ref: '#/components/responses/5xxServerError'
+
 
 ## NCBIRefSeq paths
     /genes:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -337,7 +337,7 @@ def _get_experiment(id_=None):
                             result["variants"].append(drs_obj["id"])
                         elif content["id"] == "read":
                             result["reads"].append(drs_obj["id"])
-            return result, 200
+        return result, 200
 
 
 def _get_htsget_url(id, reference_name, slice_start, slice_end, file_type, data=True):

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -137,15 +137,6 @@ def index_reads(id_=None):
         return None, 404
 
 
-@app.route('/reads/<path:id_>/verify')
-def verify_reads_analysis_drs_object(id_):
-    try:
-        _verify_analysis_drs_object(id_)
-    except Exception as e:
-        return {"result": False, "message": str(e)}, 200
-    return {"result": True}, 200
-
-
 @app.route('/variants/<path:id_>')
 def get_variants(id_=None, reference_name=None, start=None, end=None, class_=None, format_=None):
     if id_ is not None:
@@ -171,21 +162,6 @@ def get_variants_data(id_, reference_name=None, format_="VCF", start=None, end=N
     return None, auth_code
 
 
-@app.route('/variants/<path:id_>/verify')
-def verify_variants_analysis_drs_object(id_):
-    try:
-        auth_code = authz.is_authed(escape(id_), connexion.request)
-        if auth_code == 200:
-            _verify_analysis_drs_object(id_)
-        else:
-            return {"message": "User is not authorized to verify variants"}, 403
-    except Exception as e:
-        return {"result": False, "message": str(e)}, 200
-    return {"result": True}, 200
-
-
-@app.route('/variants/<path:id_>/index')
-def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
     if not authz.has_full_authz(connexion.request):
         return {"message": "User is not authorized to index variants"}, 403
     if id_ is not None:
@@ -214,6 +190,18 @@ def index_variants(id_=None, force=False, do_not_index=False, genome='hg38'):
     else:
         return None, 404
 
+
+@app.route('/<path:id_>/verify')
+def verify_analysis_drs_object(id_):
+    try:
+        auth_code = authz.is_authed(escape(id_), connexion.request)
+        if auth_code == 200:
+            _verify_analysis_drs_object(id_)
+        else:
+            return {"message": "User is not authorized to verify analysis"}, 403
+    except Exception as e:
+        return {"result": False, "message": str(e)}, 200
+    return {"result": True}, 200
 
 @app.route('/genes')
 def list_genes(type="gene_name"):

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -162,28 +162,29 @@ def get_variants_data(id_, reference_name=None, format_="VCF", start=None, end=N
     return None, auth_code
 
 
+@app.route('/<path:id_>/index')
+def index_analysis(id_=None, force=False, do_not_index=False, genome='hg38'):
     if not authz.has_full_authz(connexion.request):
-        return {"message": "User is not authorized to index variants"}, 403
+        return {"message": "User is not authorized to index analyses"}, 403
     if id_ is not None:
         # check that there is a database drs object for this:
-        drs_obj = database.get_drs_object(id_)
+        drs_obj = drs_operations._describe_drs_object(id_)
         if drs_obj is None:
             return {"message": f"No DRS object exists with ID {id_}"}, 404
-        if drs_obj['description'] not in ['variant']:
-            return {"message": f"DRS object {id_} is not an analysis object: {drs_obj['description']}"}, 404
         program = ""
         if "program" in drs_obj:
             program = drs_obj['program']
         params = {"id": id_, "reference_genome": genome}
         try:
-            varfile = database.create_variantfile(params)
-            if not do_not_index:
-                if varfile is not None:
-                    if varfile['indexed'] == 1 and not force:
-                        return varfile, 200
-                    # clear the indexed bit:
-                    database.mark_variantfile_as_not_indexed(id_)
-                Path(f"{INDEXING_PATH}/{program}~{id_}").touch()
+            if drs_obj['type'] == 'variant':
+                varfile = database.create_variantfile(params)
+                if not do_not_index:
+                    if varfile is not None:
+                        if varfile['indexed'] == 1 and not force:
+                            return varfile, 200
+                        # clear the indexed bit:
+                        database.mark_variantfile_as_not_indexed(id_)
+            Path(f"{INDEXING_PATH}/{program}~{id_}").touch()
             return None, 200
         except Exception as e:
             return {"message": str(e)}, 500

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -563,21 +563,13 @@ def _get_urls(file_type, id, reference_name=None, start=None, end=None, _class=N
 
 def _verify_analysis_drs_object(id_):
     # get the listed experiments that the AnalysisDrsObject says should be in the file
-    gen_drs_obj = database.get_drs_object(id_)
+    gen_drs_obj = drs_operations._describe_drs_object(id_)
     if gen_drs_obj is None:
         raise Exception(f"Could not find object {id_}")
-    drs_experiments = set()
-    file_type = None
-    if "contents" in gen_drs_obj and "reference_genome" in gen_drs_obj:
-        for c in gen_drs_obj["contents"]:
-            if c["id"] not in ["variant", "read", "index"]:
-                drs_experiments.add(c["id"])
-            if c["id"] in ["variant", "read"]:
-                file_type = c["id"]
-    else:
-        raise Exception(f"Object {id_} is not a AnalysisDrsObject")
-    if file_type is None:
+    drs_experiments = set(gen_drs_obj['experiments'].keys())
+    if 'type' not in gen_drs_obj:
         raise Exception(f"Object {id_} should be a AnalysisDrsObject, but does not link to a variant or read file")
+    file_type = gen_drs_obj['type']
 
     # get the experiments that are in the linked files
     gen_obj = drs_operations._get_analysis_obj(id_)

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -163,7 +163,7 @@ def get_variants_data(id_, reference_name=None, format_="VCF", start=None, end=N
 
 
 @app.route('/<path:id_>/index')
-def index_analysis(id_=None, force=False, do_not_index=False, genome='hg38'):
+def index_analysis(id_=None, force=False, genome='hg38'):
     if not authz.has_full_authz(connexion.request):
         return {"message": "User is not authorized to index analyses"}, 403
     if id_ is not None:
@@ -178,12 +178,11 @@ def index_analysis(id_=None, force=False, do_not_index=False, genome='hg38'):
         try:
             if drs_obj['type'] == 'variant':
                 varfile = database.create_variantfile(params)
-                if not do_not_index:
-                    if varfile is not None:
-                        if varfile['indexed'] == 1 and not force:
-                            return varfile, 200
-                        # clear the indexed bit:
-                        database.mark_variantfile_as_not_indexed(id_)
+                if varfile is not None:
+                    if varfile['indexed'] == 1 and not force:
+                        return varfile, 200
+                    # clear the indexed bit:
+                    database.mark_variantfile_as_not_indexed(id_)
             Path(f"{INDEXING_PATH}/{program}~{id_}").touch()
             return None, 200
         except Exception as e:

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -317,15 +317,12 @@ def _get_experiment(id_=None):
             result["transcriptomes"].append(experiment_drs_obj["id"])
         result["program"] = experiment_drs_obj["program"]
         for contents_obj in experiment_drs_obj["contents"]:
-            drs_obj = database.get_drs_object(contents_obj["id"])
+            drs_obj = drs_operations._describe_drs_object(contents_obj["id"])
             if drs_obj is not None:
-                # check the contents of this analysis drs object and see if it contains variants or reads
-                if "contents" in drs_obj:
-                    for content in drs_obj["contents"]:
-                        if content["id"] == "variant":
-                            result["variants"].append(drs_obj["id"])
-                        elif content["id"] == "read":
-                            result["reads"].append(drs_obj["id"])
+                if drs_obj["type"] == "variant":
+                    result["variants"].append(drs_obj["name"])
+                elif drs_obj["type"] == "read":
+                    result["reads"].append(drs_obj["name"])
         return result, 200
 
 

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -71,10 +71,14 @@ def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
     for r in records:
         experiments = []
         for vcf_sample in r.samples:
-            # experiments in analysis_obj are listed as {vcf_sample: experiment_id}
+            # samples in analysis_obj are listed as {vcf_sample: experiment_id}
             if "experiments" in analysis_obj and vcf_sample in analysis_obj['experiments']:
                 experiment_id = analysis_obj['experiments'][vcf_sample]
-                experiments.append(experiment_id)
+                experiment_obj = database.get_drs_object(experiment_id)
+                if experiment_obj is not None:
+                    experiments.append(experiment_obj["name"])
+                else:
+                    experiments.append(experiment_id)
             else:
                 experiments.append(vcf_sample)
         variant_record = parse_variant_record(str(r), experiments, variants_by_file['info'])

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -223,7 +223,7 @@ def index_variants():
 
 @pytest.mark.parametrize('sample', index_variants())
 def test_index_variantfile(sample):
-    url = f"{HOST}/htsget/v1/variants/{sample}/index"
+    url = f"{HOST}/htsget/v1/{sample}/index"
     params = {}
     params['force'] = True
     response = requests.get(url, params=params, headers=get_headers())
@@ -253,14 +253,19 @@ def get_ingest_file():
     return [
         (
             {
-                "genomic_id": "NA18537",
-                "samples": [
-                    {
-                        "sample_registration_id": "NA18537-wgs",
-                        "sample_name_in_file": "NA18537"
-                    }
-                ]
-            }, "1000genomes"
+                "program_id": "1000genomes",
+                "experiment_id": "LOCAL-SEQ_0090",
+                "submitter_sample_id": "NA18537-wgs",
+                "metadata": {
+                    "library_strategy": "WGS"
+                }
+            },
+            {
+                "program_id": "1000genomes",
+                "analysis_id": "NA18537",
+                "analysis_sample_id": "NA18537",
+                "experiment_id": "NA18537-wgs"
+            }
         )
     ]
 
@@ -275,13 +280,13 @@ def get_ingest_experiment_names(genomic_id):
     return result
 
 
-@pytest.mark.parametrize('input, program_id', get_ingest_file())
-def test_add_experiment_drs(input, program_id):
+@pytest.mark.parametrize('experiment, analysis', get_ingest_file())
+def test_add_experiment_drs(experiment, analysis):
     post_url = f"{HOST}/ga4gh/drs/v1/objects"
     headers = get_headers()
 
     # look for the main analysis drs object
-    get_url = f"{HOST}/ga4gh/drs/v1/objects/{input['genomic_id']}"
+    get_url = f"{HOST}/ga4gh/drs/v1/objects/{analysis['analysis_id']}"
     response = requests.request("GET", get_url, headers=headers)
     if response.status_code == 200:
         assert response.status_code == 200
@@ -289,45 +294,38 @@ def test_add_experiment_drs(input, program_id):
     contents_count = len(analysis_drs_obj["contents"])
 
     drs_url = HOST.replace("http://", "drs://").replace("https://", "drs://")
-    for experiment in input['samples']:
-        experiment_id = f"{experiment['sample_registration_id']}"
-        # remove any existing objects:
-        experiment_url = f"{HOST}/ga4gh/drs/v1/objects/{experiment_id}"
-        response = requests.request("GET", experiment_url, headers=headers)
-        if response.status_code == 200:
-            response = requests.request("DELETE", experiment_url, headers=headers)
-            print(f"DELETE {experiment_id}: {response.text}")
-            assert response.status_code == 200
 
-        # create a experimentdrsobject to correspond to each experiment:
-        experiment_drs_object = {
-            "id": experiment_id,
-            "description": "wgs",
-            "contents": [
-                {
-                    "drs_uri": [
-                        f"{drs_url}/{input['genomic_id']}"
-                    ],
-                    "name": experiment['sample_name_in_file'],
-                    "id": input['genomic_id']
-                }
-            ],
-            "version": "v1",
-            "program": program_id
-        }
-        response = requests.request("POST", post_url, json=experiment_drs_object, headers=headers)
-        print(f"POST {experiment_drs_object['id']}: {response.text}")
-        assert response.status_code == 200
+    # create a experimentdrsobject to correspond to each experiment:
+    experiment_drs_object = {
+        "id": experiment['experiment_id'],
+        "name": experiment["submitter_sample_id"],
+        "description": "wgs",
+        "program": experiment['program_id'],
+        "contents": [
+            {
+                "drs_uri": [
+                    f"{drs_url}/{analysis['analysis_id']}"
+                ],
+                "name": analysis['analysis_sample_id'],
+                "id": analysis['analysis_id']
+            }
+        ],
+        "version": "v1",
+        "metadata": {}
+    }
+    response = requests.request("POST", post_url, json=experiment_drs_object, headers=headers)
+    print(f"POST {experiment_drs_object['id']}: {response.text}")
+    assert response.status_code == 200
 
-        # add the experiment contents to the analysis_drs_object's contents
-        experiment_contents = {
-            "drs_uri": [
-                f"{drs_url}/{experiment_id}"
-            ],
-            "name": experiment_id,
-            "id": experiment['sample_name_in_file']
-        }
-        analysis_drs_obj["contents"].append(experiment_contents)
+    # add the experiment contents to the analysis_drs_object's contents
+    experiment_contents = {
+        "drs_uri": [
+            f"{drs_url}/{experiment['experiment_id']}"
+        ],
+        "name": experiment['experiment_id'],
+        "id": analysis['analysis_sample_id']
+    }
+    analysis_drs_obj["contents"].append(experiment_contents)
 
     response = requests.post(post_url, json=analysis_drs_obj, headers=get_headers())
     print(response.text)
@@ -336,18 +334,17 @@ def test_add_experiment_drs(input, program_id):
         assert response.status_code == 200
     assert len(analysis_drs_obj["contents"]) == contents_count + 1
 
-    verify_url = f"{HOST}/htsget/v1/variants/{input['genomic_id']}/verify"
+    verify_url = f"{HOST}/htsget/v1/{analysis["analysis_id"]}/verify"
     response = requests.get(verify_url, headers=get_headers())
     print(response.text)
     assert response.status_code == 200
 
 
-@pytest.mark.parametrize('input, program_id', get_ingest_file())
-def test_experiment_stats(input, program_id):
+@pytest.mark.parametrize('experiment, analysis', get_ingest_file())
+def test_experiment_stats(experiment, analysis):
     headers = get_headers()
 
-    experiments = get_ingest_experiment_names(input['genomic_id'])
-    experiment = list(experiments.keys()).pop()
+    experiment = experiment['experiment_id']
     # look for the experiment
     get_url = f"{HOST}/htsget/v1/experiments/{experiment}"
     response = requests.request("GET", get_url, headers=headers)
@@ -597,7 +594,7 @@ def drs_objects():
         # make a analysisdrsobj:
         analysis_drs_obj = {
             "id": drs_obj,
-            "description": type,
+            "description": "analysis",
             "mime_type": "application/octet-stream",
             "name": drs_obj,
             "contents": [],
@@ -627,7 +624,7 @@ def drs_objects():
         # make a analysisdatadrsobj:
         result.append({
             "id": data_file,
-            "description": type,
+            "description": "analysis",
             "mime_type": "application/octet-stream",
             "name": data_file,
             "version": "v1",


### PR DESCRIPTION
The main changes in htsget are to add the metadata json to the drs object table in the database and to consolidate index and verify for either variants or reads and not have them be separate. 

I also had to update tests to match.