### PR TITLE
DIG-2002, DIG-2003: htsget allows file downloads, file size available

### DIFF
--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -448,7 +448,7 @@ components:
       type: object
     HandoverType:
       type: object
-      description: in our context, only htsget urls should be returned
+      description: in our context, only htsget or download urls should be returned
       properties:
         id:
           type: string
@@ -458,6 +458,7 @@ components:
           type: string
           enum:
             - HTSGET
+            - DOWNLOAD
     IncludeResultsetResponses:
       default: HIT
       description: Indicator of whether responses from every Resultset should be included in the response to this request or just the ones with positive, negative results or no details at all. If null (not specified), the default value of 'HIT' is assumed. This parameter allows for returning boolean/counting results although the Beacon instance is capable to return record level details.

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -300,23 +300,35 @@ def search(raw_req):
             # look for experiments and programs for all drs objects, even if user is not authorized
             drs_obj = database.get_drs_object(drs_obj_id)
             if "program" in drs_obj:
+                download_handovers = []
                 if drs_obj["program"] not in query_info:
                     query_info[drs_obj["program"]] = []
                 for c in drs_obj["contents"]:
-                    if c["id"] not in ["variant", "read", "index"]:
+                    if c["id"] not in ["variant", "read", "transcript", "index"]:
                         # this is a ExperimentContentObject
                         if c["name"] not in query_info[drs_obj["program"]]:
                             query_info[drs_obj["program"]].append(c["name"])
-
+                    else:
+                        # this is a file that we should create a download url for
+                        file_drs_obj = database.get_drs_object(c["name"])
+                        download_handover = {
+                            'handoverType': {'id': 'CUSTOM', 'label': 'DOWNLOAD'},
+                            'url': drs_operations._get_download_url(file_drs_obj['id'])
+                        }
+                        if 'size' in file_drs_obj:
+                            download_handover['note'] = f"size {file_drs_obj['size']} bytes"
+                        download_handovers.append(download_handover)
                 if drs_obj["program"] in authed_programs:
-                    # fill in handover data
+                    # fill in htsget handover data
                     try:
-                        handover, status_code = htsget_operations._get_urls("variant", drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+                        htsget_handover, status_code = htsget_operations._get_urls("variant", drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
                     except Exception as e:
                         raise Exception(f"exception in get_variants for {drs_obj_id}: {type(e)} {str(e)}")
-                    if handover is not None:
-                        handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
-                        response['beaconHandovers'].append(handover)
+                    if htsget_handover is not None:
+                        htsget_handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
+                        response['beaconHandovers'].append(htsget_handover)
+                    if len(download_handovers) > 0:
+                        response['beaconHandovers'].extend(download_handovers)
         if len(response['beaconHandovers']) > 0 and meta['returnedGranularity'] == 'record':
             response['response'] = resultset
             if len(resultset) > 0: # use true number if we're authorized, even if below AGGREGATE_COUNT_THRESHOLD

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -308,7 +308,7 @@ def search(raw_req):
                         # this is a ExperimentContentObject
                         if c["name"] not in query_info[drs_obj["program"]]:
                             query_info[drs_obj["program"]].append(c["name"])
-                    else:
+                    elif c["id"] in ["variant", "transcript", "index"]:
                         # this is a file that we should create a download url for
                         file_drs_obj = database.get_drs_object(c["name"])
                         download_handover = {
@@ -316,7 +316,7 @@ def search(raw_req):
                             'url': drs_operations._get_download_url(file_drs_obj['id'])
                         }
                         if 'size' in file_drs_obj:
-                            download_handover['note'] = f"size {file_drs_obj['size']} bytes"
+                            download_handover['size'] = file_drs_obj['size']
                         download_handovers.append(download_handover)
                 if drs_obj["program"] in authed_programs:
                     # fill in htsget handover data

--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -393,12 +393,15 @@ def get_drs_object(object_id, expand=False, tries=1):
     return None
 
 
-def list_drs_objects(program_id=None):
+def list_drs_objects(program_id=None, sample_registration_id=None):
     with Session() as session:
-        if program_id is not None:
-            result = session.query(DrsObject).filter_by(program_id=program_id).all()
-        else:
+        if program_id is None and sample_registration_id is None:
             result = session.query(DrsObject).all()
+        elif sample_registration_id is None: # searching for program
+            result = session.query(DrsObject).filter_by(program_id=program_id).all()
+        else: # searching for experiments with sample registration IDs
+            result = session.query(DrsObject).filter_by(name=sample_registration_id).all()
+
         if result is not None:
             new_obj = json.loads(str(result))
             return new_obj

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -823,7 +823,7 @@ components:
           description: The submitter_sample_id of the experiment in the MoH model
         id:
           type: string
-          description: The id of the ExperimentDrsObject, corresponding to the sample's name in the VCF file
+          description: The id of the ExperimentDrsObject
         drs_uri:
           type: array
           description: The DRS uri(s) to the ExperimentDrsObject

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -32,6 +32,7 @@ paths:
       summary: List all DRS objects
       parameters:
       - $ref: '#/components/parameters/ProgramIdQuery'
+      - $ref: '#/components/parameters/SampleRegistrationQuery'
       description: >-
         Returns object metadata, and a list of access methods that can be used to fetch object bytes.
       operationId: drs_operations.list_objects
@@ -212,6 +213,12 @@ components:
         in: query
         name: program_id
         description: ProgramId
+        schema:
+          type: string
+    SampleRegistrationQuery:
+        in: query
+        name: sample_registration_id
+        description: sample_registration_id from mohccn data model
         schema:
           type: string
     ObjectId:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -96,6 +96,21 @@ paths:
                   - $ref: '#/components/schemas/AnalysisDrsObject'
       tags:
         - Objects
+  /objects/{object_id}/download:
+    parameters:
+        - $ref: '#/components/parameters/ObjectId'
+        - $ref: '#/components/parameters/BearerAuth'
+    get:
+      summary: Download a file associated with a drs object
+      description: downloads the file.
+      operationId: drs_operations.download_file
+      responses:
+        200:
+          description: The `DrsObject` was found successfully
+          content:
+            application/octet-stream: {}
+      tags:
+        - Objects
 
   /objects/{object_id}/access/{access_id}:
     get:

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -91,6 +91,12 @@ async def post_object(tries=1):
         sleep(randint(1,10)/2)
     try:
         new_object = database.create_drs_object(req)
+
+        # if this is a file drs object, put the size in
+        response = _get_file_path(object_id)
+        if response["status_code"] == 200:
+            new_object['size'] = response['size']
+            new_object = database.create_drs_object(new_object)
     except Exception as e:
         logger.debug(f"Exception in post_object {object_id}: {str(e)}, trying again")
         return post_object(tries=tries+1)
@@ -274,6 +280,10 @@ def _get_file_path(drs_file_obj_id):
         return result
     # get access_methods for this drs_file_obj
     url = ""
+    if "access_methods" not in drs_file_obj:
+        result["message"] = f"Object {drs_file_obj_id} is not a file"
+        result['status_code'] = 400
+        return result
     for method in drs_file_obj["access_methods"]:
         if "access_id" in method and method["access_id"] != "":
             # we need to go to the access endpoint to get the url and file

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -90,6 +90,10 @@ def download_file(object_id, request=connexion.request):
         return {"message": f"No object {object_id} was found"}, 404
     if "access_methods" not in drs_object:
         return {"message": f"No files are associated with object {object_id}"}, 404
+    if "metadata" in drs_object:
+        if "analysis_type" in drs_object["metadata"]:
+            if drs_object["metadata"]["analysis_type"] == "reference_alignment":
+                return {"message": f"Sorry, read files are not allowed to be downloaded"}, 403
     for method in drs_object["access_methods"]:
         if "access_url" in method:
             file_obj = _get_file_path(drs_object["id"])

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -1,6 +1,7 @@
 import connexion
 import database
-from flask import Flask
+from flask import Flask, send_file, Response
+import requests
 import os
 import os.path
 import re
@@ -8,7 +9,7 @@ import authz
 from markupsafe import escape
 from pysam import VariantFile, AlignmentFile
 from urllib.parse import parse_qs, urlparse, urlencode
-from config import INDEXING_PATH
+from config import INDEXING_PATH, HTSGET_URL
 from time import sleep
 from random import randint
 from candigv2_logging.logging import CanDIGLogger
@@ -76,6 +77,30 @@ def get_access_url(object_id, access_id, request=connexion.request):
         if auth_code != 200:
             return {"message": f"Not authorized to access object {object_id}"}, auth_code
     return _get_access_url(access_id)
+
+
+@app.route('/ga4gh/drs/v1/objects/<object_id>/download')
+def download_file(object_id, request=connexion.request):
+    def generate(url):
+        with requests.get(url, stream=True) as r:
+            yield r.iter_content(), 200
+    if object_id is not None:
+        auth_code = authz.is_authed(escape(object_id), connexion.request)
+        if auth_code != 200:
+            return {"message": f"Not authorized to access object {object_id}"}, auth_code
+    drs_object = database.get_drs_object(escape(object_id))
+    if drs_object is None:
+        return {"message": f"No object {object_id} was found"}, 404
+    if "access_methods" not in drs_object:
+        return {"message": f"No files are associated with object {object_id}"}, 404
+    for method in drs_object["access_methods"]:
+        if "access_url" in method:
+            file_obj = _get_file_path(drs_object["id"])
+            return send_file(file_obj["path"]), 200
+        else:
+            url, status_code = _get_access_url(method["access_id"])
+            r = requests.get(url["url"], stream=True)
+            return Response(r.iter_content(chunk_size=10*1024), content_type=r.headers['Content-Type'])
 
 
 async def post_object(tries=1):
@@ -349,3 +374,8 @@ def _get_access_url(access_id):
         return url, 500
     else:
         return {"message": f"Malformed access_id {access_id}: should be in the form endpoint/bucket/item", "method": "_get_access_url"}, 400
+
+
+# convenience method for other methods to easily get the download url
+def _get_download_url(drs_file_obj_id):
+    return f"{HTSGET_URL}/ga4gh/drs/v1/objects/{drs_file_obj_id}/download"

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -81,9 +81,6 @@ def get_access_url(object_id, access_id, request=connexion.request):
 
 @app.route('/ga4gh/drs/v1/objects/<object_id>/download')
 def download_file(object_id, request=connexion.request):
-    def generate(url):
-        with requests.get(url, stream=True) as r:
-            yield r.iter_content(), 200
     if object_id is not None:
         auth_code = authz.is_authed(escape(object_id), connexion.request)
         if auth_code != 200:

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -65,8 +65,8 @@ def get_object_for_drs_uri(drs_uri):
     return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}, 401
 
 
-def list_objects(program_id=None):
-    return database.list_drs_objects(program_id=program_id), 200
+def list_objects(program_id=None, sample_registration_id=None):
+    return database.list_drs_objects(program_id=program_id, sample_registration_id=sample_registration_id), 200
 
 
 @app.route('/ga4gh/drs/v1/objects/<object_id>/access_url/<path:access_id>')

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -92,7 +92,7 @@ def download_file(object_id, request=connexion.request):
         return {"message": f"No files are associated with object {object_id}"}, 404
     if "metadata" in drs_object:
         if "analysis_type" in drs_object["metadata"]:
-            if drs_object["metadata"]["analysis_type"] == "reference_alignment":
+            if "metadata" in drs_object and drs_object["metadata"] is not None:
                 return {"message": f"Sorry, read files are not allowed to be downloaded"}, 403
     for method in drs_object["access_methods"]:
         if "access_url" in method:

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -189,7 +189,7 @@ def test_install_public_object():
                 "id": "index"
               }
             ],
-            "description": "variant",
+            "description": "sequence_variation",
             "reference_genome": "hg38",
             "id": "ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes",
             "mime_type": "application/octet-stream",


### PR DESCRIPTION
Files get their file size saved on object creation; size is accessible at the file drs object's endpoint (e.g. `/ga4gh/drs/v1/objects/<filename>`)

Direct download of those files are available at `/ga4gh/drs/v1/objects/<filename>/download`; those URLs are also available as handovers with custom type DOWNLOAD.