### PR TITLE
DIG-2021: Separate quick search from full beacon search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
       DB_PATH: localhost
       SERVER_LOCAL_DATA: ${{github.workspace}}/data
       PGPASSWORD: OG0pjmnQDWUTvLotYrxPrg
-      INDEXING_PATH: ${{github.workspace}}/tmp
+      INDEXING_PATH: ${{github.workspace}}/tmp/indexer
+      SEARCH_PATH: ${{github.workspace}}/tmp/search
       INDEXING_SWITCH_FILE: ${{github.workspace}}/indexer_on
       TESTENV_URL: http://localhost:3000
       AGGREGATE_COUNT_THRESHOLD: 5
@@ -52,6 +53,8 @@ jobs:
         pip install -r requirements.txt
         bash create_db.sh
         mkdir -p ${{ env.INDEXING_PATH }}
+        mkdir -p ${{ env.SEARCH_PATH }}/results
+        mkdir -p ${{ env.SEARCH_PATH }}/to_search
         touch ${{ env.INDEXING_SWITCH_FILE }}
         sed -i s@\<AGGREGATE_COUNT_THRESHOLD\>@${{env.AGGREGATE_COUNT_THRESHOLD}}@ config.ini
         sed -i s@\<POSTGRES_USERNAME\>@${{env.POSTGRES_USERNAME}}@ config.ini
@@ -59,5 +62,6 @@ jobs:
       run: |
         python htsget_server/server.py &
         python htsget_server/indexing.py &
+        python htsget_server/search.py &
         sleep 5
         pytest tests/test_htsget_server.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,9 @@ if [[ -f "initial_setup" ]]; then
     sed -i s@\<POSTGRES_USERNAME\>@$POSTGRES_USERNAME@ config.ini
 
     bash create_db.sh
-    mkdir $INDEXING_PATH
+    mkdir -p $INDEXING_PATH
+    mkdir -p $SEARCH_PATH/results
+    mkdir -p $SEARCH_PATH/to_search
     touch $INDEXING_SWITCH_FILE
     rm initial_setup
 fi
@@ -24,6 +26,7 @@ candigv2_logging.logging.initialize()"
 #python3 htsget_server/server.py
 
 bash htsget_server/indexing.sh &
+bash htsget_server/search.sh &
 
 # use the following instead for production deployment
 cd htsget_server

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -643,7 +643,7 @@ components:
       description: Result with initial estimated data and a link to full Beacon result
       type: object
       properties:
-        fullResultUrl:
+        beaconResultUrl:
           type: string
         estimatedResults:
           type: array

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -109,6 +109,25 @@ paths:
           description: Successful operation
       tags:
         - Informational endpoints
+  /result/{queue_id}:
+    parameters:
+      - in: path
+        required: true
+        name: queue_id
+        schema:
+          type: string
+    get:
+      description: Get full Beacon result for a search
+      operationId: beacon_operations.get_full_result
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BeaconResultsetsResponseBody"
+        '404':
+          description: Not Found
   /g_variants:
     get:
       description: Search for variants
@@ -262,7 +281,7 @@ components:
             oneOf:
               - $ref: "#/components/schemas/BeaconBooleanResponseBody"
               - $ref: "#/components/schemas/BeaconCountResponseBody"
-              - $ref: "#/components/schemas/BeaconResultsetsResponseBody"
+              - $ref: "#/components/schemas/BeaconSearchResponseBody"
       description: Successful operation.
     BeaconErrorResponse:
       description: An unsuccessful operation.
@@ -324,6 +343,22 @@ components:
       required:
         - meta
         - responseSummary
+      type: object
+    BeaconSearchResponseBody:
+      description: Beacon quick search result
+      properties:
+        info:
+          $ref: '#/components/schemas/Info'
+        meta:
+          $ref: '#/components/schemas/BeaconResponseMeta'
+        response:
+          $ref: '#/components/schemas/QuickSearchResult'
+        responseSummary:
+          $ref: '#/components/schemas/BeaconSummaryResponseSection'
+      required:
+        - meta
+        - responseSummary
+        - response
       type: object
     BeaconResultsetsResponseBody:
       description: Beacon response that includes record level details, grouped in Resultsets.
@@ -604,6 +639,23 @@ components:
         - resultSets
       title: Beacon ResultSet
       type: object
+    QuickSearchResult:
+      description: Result with initial estimated data and a link to full Beacon result
+      type: object
+      properties:
+        fullResultUrl:
+          type: string
+        estimatedResults:
+          type: array
+          items:
+            type: object
+            properties:
+              analysisId:
+                type: string
+              programId:
+                type: string
+              variantCount:
+                type: integer
     BeaconCountResponseSection:
       description: Payload definition for the "count" response.
       properties:
@@ -885,6 +937,7 @@ components:
                 type: string
               genotype:
                 type: object
+                description: based on suggested modification at https://github.com/ga4gh-beacon/beacon-v2/issues/57#issuecomment-1452561660
                 properties:
                   zygosity:
                     $ref: '#/components/schemas/OntologyTerm'

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -324,8 +324,8 @@ def get_full_result(queue_id):
                 json_data.pop("complete")
                 return json_data["result"], 201
             return json_data, 200
-    except:
-        return {"error": f"no such queue_id {queue_id}"}, 404
+    except Exception as e:
+        return {"error": f"no such queue_id {queue_id}: {type(e)} {str(e)}"}, 404
 
 
 def full_beacon_search(search_json):

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -146,6 +146,9 @@ async def post_search():
     except Exception as e:
         return {'message': f"{type(e)}: {str(e)}"}, 500
 
+@app.route('/beacon/v2/result/<path:queue_id>')
+def get_full_result(queue_id):
+    return None
 
 def search(raw_req):
     req = raw_req['query']['requestParameters']

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -287,6 +287,10 @@ def search(raw_req):
                 if program in results:
                     response["estimatedResults"][program] = results[program]
 
+        # if the user isn't authorized for any useful data, just return a boolean about whether or not we found anything
+        if len(response["estimatedResults"]) == 0:
+            response["estimatedResults"] = {"exists": len(potential_hits) > 0}
+
         # remove irrelevant meta stuff:
         response["meta"].pop("returnedGranularity")
         response["meta"].pop("returnedSchemas")

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -8,7 +8,10 @@ import re
 import connexion
 from functools import reduce
 import authz
-from config import AGGREGATE_COUNT_THRESHOLD
+import uuid
+import tempfile
+import os
+from config import AGGREGATE_COUNT_THRESHOLD, SEARCH_PATH, HTSGET_URL, BUCKET_SIZE
 from candigv2_logging.logging import CanDIGLogger
 
 
@@ -146,9 +149,6 @@ async def post_search():
     except Exception as e:
         return {'message': f"{type(e)}: {str(e)}"}, 500
 
-@app.route('/beacon/v2/result/<path:queue_id>')
-def get_full_result(queue_id):
-    return None
 
 def search(raw_req):
     req = raw_req['query']['requestParameters']
@@ -174,11 +174,7 @@ def search(raw_req):
     # if 'includeResultsetResponses' in raw_req:
     #     meta['receivedRequestSummary']['includeResultsetResponses'] = raw_req['includeResultsetResponses']
     response = {
-        'meta': meta,
-        'responseSummary': {
-            'exists': False,
-            'numTotalResults': 0
-        }
+        'meta': meta
     }
 
     actual_params = meta['receivedRequestSummary']['requestParameters']
@@ -232,8 +228,8 @@ def search(raw_req):
             raise Exception(f"exception in convert_hgvsid_to_location for {req['genomic_allele_short_form']}: {type(e)} {str(e)}")
         if allele_loc is not None:
             actual_params['reference_name'] = allele_loc['reference_name']
-            actual_params['start'] = allele_loc['start']
-            actual_params['end'] = allele_loc['end']
+            actual_params['start'] = int(allele_loc['start']) - 1 # search for bases starting at the interbase half-a-base back
+            actual_params['end'] = int(allele_loc['end'])
             # actual_params['type'] = allele_loc['type']
             if 'reference_genome' in allele_loc:
                 actual_params['reference_genome'] = allele_loc['reference_genome']
@@ -243,109 +239,64 @@ def search(raw_req):
                 actual_params['alt'] = allele_loc['alt']
 
     if 'reference_name' in actual_params and actual_params['reference_name'] is not None:
+        authed_programs = authz.get_authorized_programs(connexion.request)
+
         # if there is no end specified, assume the end is same as start:
         if 'end' not in actual_params:
             actual_params['end'] = actual_params['start']
         try:
-            variants_by_file = variants.find_variants_in_region(reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+            potential_hits = variants.find_variants_in_database(reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
         except Exception as e:
-            raise Exception(f"exception in find_variants_in_region for {actual_params}: {type(e)} {str(e)}")
-        try:
-            resultset = compile_beacon_resultset(variants_by_file, reference_genome=actual_params['reference_genome'])
-        except Exception as e:
-            raise Exception(f"exception in compile_beacon_resultset for {actual_params}: {type(e)} {str(e)}")
-        # others are for filtering after:
-        #         aminoacidChange: string,
-        #         alternate_bases: string,
-        #         reference_bases: string,
-        #         variant_max_length: integer
-        #         variant_min_length: integer
-        #         variantType: string
+            raise Exception(f"exception in search for {actual_params}: {type(e)} {str(e)}")
 
-        if actual_params['start'] == actual_params['end']:
-            filtered_resultset = []
-            for variant in resultset:
-                if variant['variation']['location']['interval']['start']['value'] == actual_params['start'] - 1:
-                    if variant['variation']['location']['interval']['end']['value'] == actual_params['end']:
-                        filtered_resultset.append(variant)
-            resultset = filtered_resultset
-        if 'alt' in actual_params:
-            filtered_resultset = []
-            for variant in resultset:
-                if variant['variantInternalId'].endswith('='):
-                    filtered_resultset.append(variant) # don't filter out ref seqs
-                elif variants.seq_match(variant['variation']['state']['sequence'], actual_params['alt']):
-                    filtered_resultset.append(variant)
-            resultset = filtered_resultset
-        if 'ref' in actual_params:
-            filtered_resultset = []
-            for variant in resultset:
-                if variant['variantInternalId'].endswith('='):
-                    if variants.seq_match(variant['variation']['state']['sequence'], actual_params['ref']):
-                        filtered_resultset.append(variant)
-                else:
-                    filtered_resultset.append(variant)
-            resultset = filtered_resultset
-
-
-        if len(resultset) > 0:
-            if len(resultset) < int(AGGREGATE_COUNT_THRESHOLD):
-                response['responseSummary']['numTotalResults'] = f"<{AGGREGATE_COUNT_THRESHOLD}"
-            else:
-                response['responseSummary']['numTotalResults'] = len(resultset)
-            response['responseSummary']['exists'] = True
-
-        # if the request granularity was "record", check to see that the user is actually authorized to see any programs:
-        authed_programs = authz.get_authorized_programs(connexion.request)
-        response['beaconHandovers'] = []
+        results = {}
         query_info = {} # program_id and submitter_sample_id
-        for drs_obj_id in variants_by_file.keys():
+        for i in range(len(potential_hits)):
+            drs_obj_id = potential_hits[i]['drs_object_id']
             # look for experiments and programs for all drs objects, even if user is not authorized
             drs_obj = database.get_drs_object(drs_obj_id)
             if "program" in drs_obj:
-                download_handovers = []
                 if drs_obj["program"] not in query_info:
                     query_info[drs_obj["program"]] = []
+                    results[drs_obj["program"]] = []
                 for c in drs_obj["contents"]:
-                    if c["id"] not in ["variant", "read", "transcript", "index"]:
+                    if c["id"] not in ["analysis", "index"]:
                         # this is a ExperimentContentObject
+                        res = {"submitter_sample_id": c["name"], "variant_count": potential_hits[i]["variantcount"]}
+                        results[drs_obj["program"]].append(res)
                         if c["name"] not in query_info[drs_obj["program"]]:
                             query_info[drs_obj["program"]].append(c["name"])
-                    elif c["id"] in ["variant", "transcript", "index"]:
-                        # this is a file that we should create a download url for
-                        file_drs_obj = database.get_drs_object(c["name"])
-                        download_handover = {
-                            'handoverType': {'id': 'CUSTOM', 'label': 'DOWNLOAD'},
-                            'url': drs_operations._get_download_url(file_drs_obj['id'])
-                        }
-                        if 'size' in file_drs_obj:
-                            download_handover['size'] = file_drs_obj['size']
-                        download_handovers.append(download_handover)
-                if drs_obj["program"] in authed_programs:
-                    # fill in htsget handover data
-                    try:
-                        htsget_handover, status_code = htsget_operations._get_urls("variant", drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
-                    except Exception as e:
-                        raise Exception(f"exception in get_variants for {drs_obj_id}: {type(e)} {str(e)}")
-                    if htsget_handover is not None:
-                        htsget_handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
-                        response['beaconHandovers'].append(htsget_handover)
-                    if len(download_handovers) > 0:
-                        response['beaconHandovers'].extend(download_handovers)
-        if len(response['beaconHandovers']) > 0 and meta['returnedGranularity'] == 'record':
-            response['response'] = resultset
-            if len(resultset) > 0: # use true number if we're authorized, even if below AGGREGATE_COUNT_THRESHOLD
-                response['responseSummary']['numTotalResults'] = len(resultset)
 
-        else:
-            response.pop('beaconHandovers')
-            if meta['returnedGranularity'] == 'boolean':
-                response['responseSummary'].pop('numTotalResults')
-        # if the requester is the query microservice, add query info to the results
+        search_json = {
+            "potential_hits": potential_hits,
+            "actual_params": actual_params,
+            "meta": meta,
+            "authed_programs": authed_programs
+        }
+        queue_id = add_to_queue(search_json)
+        response["beaconResultUrl"] = f"{HTSGET_URL}/beacon/v2/result/{queue_id}"
+
+        # set up quick beacon results:
+        response["estimatedSearchParameters"] = {
+            "referenceName": actual_params['reference_name'],
+            "start": database.get_bucket_for_position(actual_params["start"]),
+            "end": int(database.get_bucket_for_position(actual_params["end"])) + BUCKET_SIZE - 1
+        }
+
+        response["estimatedResults"] = {}
         if authz.request_is_from_query(connexion.request):
-            response["query_info"] = query_info
+            response["estimatedResults"] = results
+        elif len(authed_programs) > 0:
+            for program in authed_programs:
+                if program in results:
+                    response["estimatedResults"][program] = results[program]
+
+        # remove irrelevant meta stuff:
+        response["meta"].pop("returnedGranularity")
+        response["meta"].pop("returnedSchemas")
+        return response
     else:
-        response = {
+        return {
             'error': {
                 'errorMessage': 'no referenceName was provided',
                 'errorCode': 404
@@ -355,7 +306,140 @@ def search(raw_req):
     return response
 
 
-def compile_beacon_resultset(variants_by_obj, reference_genome="hg38"):
+def add_to_queue(ingest_json):
+    queue_id = str(uuid.uuid1())
+    with tempfile.NamedTemporaryFile(delete_on_close=False, mode="w") as f:
+        json.dump(ingest_json, f, indent=4)
+        os.rename(f.name, os.path.join(SEARCH_PATH, "to_search", queue_id))
+    results_path = os.path.join(SEARCH_PATH, "results", queue_id)
+    with open(results_path, "w") as f:
+        json.dump({"status": "still in queue"}, f)
+    return queue_id
+
+
+@app.route('/beacon/v2/result/<path:queue_id>')
+def get_full_result(queue_id):
+    try:
+        results_path = os.path.join(SEARCH_PATH, "results", queue_id)
+        with open(results_path) as f:
+            json_data = json.load(f)
+            # os.remove(results_path)
+            if "complete" in json_data:
+                json_data.pop("complete")
+                return json_data["result"], 201
+            return json_data, 200
+    except:
+        return {"error": f"no such queue_id {queue_id}"}, 404
+
+
+def full_beacon_search(search_json):
+    potential_hits = search_json["potential_hits"]
+    actual_params = search_json["actual_params"]
+    meta = search_json["meta"]
+    authed_programs = search_json["authed_programs"]
+
+    response = {
+        'meta': meta,
+        'responseSummary': {
+            'exists': False,
+            'numTotalResults': 0
+        }
+    }
+
+    try:
+        variants_by_file = variants.find_variants_in_files(potential_hits, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+        resultset = compile_beacon_resultset(variants_by_file, actual_params['reference_genome'], authed_programs)
+    except Exception as e:
+        raise Exception(f"exception in compile_beacon_resultset for {actual_params}: {type(e)} {str(e)}")
+    # others are for filtering after:
+    #         aminoacidChange: string,
+    #         alternate_bases: string,
+    #         reference_bases: string,
+    #         variant_max_length: integer
+    #         variant_min_length: integer
+    #         variantType: string
+
+    if actual_params['start'] == actual_params['end']:
+        filtered_resultset = []
+        for variant in resultset:
+            if variant['variation']['location']['interval']['start']['value'] == actual_params['start'] - 1:
+                if variant['variation']['location']['interval']['end']['value'] == actual_params['end']:
+                    filtered_resultset.append(variant)
+        resultset = filtered_resultset
+    if 'alt' in actual_params:
+        filtered_resultset = []
+        for variant in resultset:
+            if variant['variantInternalId'].endswith('='):
+                filtered_resultset.append(variant) # don't filter out ref seqs
+            elif variants.seq_match(variant['variation']['state']['sequence'], actual_params['alt']):
+                filtered_resultset.append(variant)
+        resultset = filtered_resultset
+    if 'ref' in actual_params:
+        filtered_resultset = []
+        for variant in resultset:
+            if variant['variantInternalId'].endswith('='):
+                if variants.seq_match(variant['variation']['state']['sequence'], actual_params['ref']):
+                    filtered_resultset.append(variant)
+            else:
+                filtered_resultset.append(variant)
+        resultset = filtered_resultset
+
+    if len(resultset) > 0:
+        if len(resultset) < int(AGGREGATE_COUNT_THRESHOLD):
+            response['responseSummary']['numTotalResults'] = f"<{AGGREGATE_COUNT_THRESHOLD}"
+        else:
+            response['responseSummary']['numTotalResults'] = len(resultset)
+        response['responseSummary']['exists'] = True
+
+    # if the request granularity was "record", check to see that the user is actually authorized to see any programs:
+    response['beaconHandovers'] = []
+    query_info = {} # program_id and submitter_sample_id
+    for drs_obj_id in variants_by_file.keys():
+        # look for experiments and programs for all drs objects, even if user is not authorized
+        drs_obj = database.get_drs_object(drs_obj_id)
+        if "program" in drs_obj:
+            download_handovers = []
+            if drs_obj["program"] not in query_info:
+                query_info[drs_obj["program"]] = []
+            for c in drs_obj["contents"]:
+                if c["id"] not in ["variant", "read", "transcript", "index"]:
+                    # this is a ExperimentContentObject
+                    if c["name"] not in query_info[drs_obj["program"]]:
+                        query_info[drs_obj["program"]].append(c["name"])
+                elif c["id"] in ["variant", "transcript", "index"]:
+                    # this is a file that we should create a download url for
+                    file_drs_obj = database.get_drs_object(c["name"])
+                    download_handover = {
+                        'handoverType': {'id': 'CUSTOM', 'label': 'DOWNLOAD'},
+                        'url': drs_operations._get_download_url(file_drs_obj['id'])
+                    }
+                    if 'size' in file_drs_obj:
+                        download_handover['size'] = file_drs_obj['size']
+                    download_handovers.append(download_handover)
+            if drs_obj["program"] in authed_programs:
+                # fill in htsget handover data
+                try:
+                    htsget_handover, status_code = htsget_operations._get_urls("variant", drs_obj_id, reference_name=actual_params['reference_name'], start=actual_params['start'], end=actual_params['end'])
+                except Exception as e:
+                    raise Exception(f"exception in get_variants for {drs_obj_id}: {type(e)} {str(e)}")
+                if htsget_handover is not None:
+                    htsget_handover['handoverType'] = {'id': 'CUSTOM', 'label': 'HTSGET'}
+                    response['beaconHandovers'].append(htsget_handover)
+                if len(download_handovers) > 0:
+                    response['beaconHandovers'].extend(download_handovers)
+    if len(response['beaconHandovers']) > 0 and meta['returnedGranularity'] == 'record':
+        response['response'] = resultset
+        if len(resultset) > 0: # use true number if we're authorized, even if below AGGREGATE_COUNT_THRESHOLD
+            response['responseSummary']['numTotalResults'] = len(resultset)
+
+    else:
+        response.pop('beaconHandovers')
+        if meta['returnedGranularity'] == 'boolean':
+            response['responseSummary'].pop('numTotalResults')
+    return response
+
+
+def compile_beacon_resultset(variants_by_obj, reference_genome="hg38", authed_programs=None):
     """
     Each beacon result describes a variation at a specific position:
     resultset = [
@@ -391,7 +475,6 @@ def compile_beacon_resultset(variants_by_obj, reference_genome="hg38"):
       ]
     """
     resultset = {}
-    authed_programs = authz.get_authorized_programs(connexion.request)
     for drs_obj in variants_by_obj.keys():
         # check to see if this drs_object is authorized:
         x = database.get_drs_object(drs_obj)

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -250,22 +250,18 @@ def search(raw_req):
             raise Exception(f"exception in search for {actual_params}: {type(e)} {str(e)}")
 
         results = {}
-        query_info = {} # program_id and submitter_sample_id
         for i in range(len(potential_hits)):
             drs_obj_id = potential_hits[i]['drs_object_id']
             # look for experiments and programs for all drs objects, even if user is not authorized
             drs_obj = database.get_drs_object(drs_obj_id)
             if "program" in drs_obj:
-                if drs_obj["program"] not in query_info:
-                    query_info[drs_obj["program"]] = []
+                if drs_obj["program"] not in results:
                     results[drs_obj["program"]] = []
                 for c in drs_obj["contents"]:
                     if c["id"] not in ["analysis", "index"]:
                         # this is a ExperimentContentObject
                         res = {"submitter_sample_id": c["name"], "variant_count": potential_hits[i]["variantcount"]}
                         results[drs_obj["program"]].append(res)
-                        if c["name"] not in query_info[drs_obj["program"]]:
-                            query_info[drs_obj["program"]].append(c["name"])
 
         search_json = {
             "potential_hits": potential_hits,
@@ -393,20 +389,13 @@ def full_beacon_search(search_json):
 
     # if the request granularity was "record", check to see that the user is actually authorized to see any programs:
     response['beaconHandovers'] = []
-    query_info = {} # program_id and submitter_sample_id
     for drs_obj_id in variants_by_file.keys():
         # look for experiments and programs for all drs objects, even if user is not authorized
         drs_obj = database.get_drs_object(drs_obj_id)
         if "program" in drs_obj:
             download_handovers = []
-            if drs_obj["program"] not in query_info:
-                query_info[drs_obj["program"]] = []
             for c in drs_obj["contents"]:
-                if c["id"] not in ["variant", "read", "transcript", "index"]:
-                    # this is a ExperimentContentObject
-                    if c["name"] not in query_info[drs_obj["program"]]:
-                        query_info[drs_obj["program"]].append(c["name"])
-                elif c["id"] in ["variant", "transcript", "index"]:
+                if c["id"] in ["analysis", "index"]:
                     # this is a file that we should create a download url for
                     file_drs_obj = database.get_drs_object(c["name"])
                     download_handover = {

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -35,5 +35,6 @@ DEBUG_MODE = False
 if os.getenv("DEBUG_MODE", "1") == "1":
     DEBUG_MODE = True
 
-INDEXING_PATH = os.getenv("INDEXING_PATH", "~/tmp")
+INDEXING_PATH = os.getenv("INDEXING_PATH", "~/tmp/indexing")
+SEARCH_PATH = os.getenv("SEARCH_PATH", "~/tmp/search")
 INDEXING_SWITCH_FILE = os.getenv("INDEXING_SWITCH_FILE", "~/indexing_on")

--- a/htsget_server/search.py
+++ b/htsget_server/search.py
@@ -5,6 +5,7 @@ import watchdog.events
 from candigv2_logging.logging import initialize, CanDIGLogger
 import json
 from beacon_operations import full_beacon_search
+from time import time
 
 
 logger = CanDIGLogger(__file__)
@@ -32,6 +33,15 @@ def search_file(file_path):
         status_code = 500
     with open(results_path, "w") as f:
         json.dump(results, f)
+
+    # clean up old search results
+    results_path = os.path.join(SEARCH_PATH, "results")
+    for filename in os.listdir(results_path):
+        file_path = os.path.join(results_path, filename)
+        filestamp = os.stat(file_path).st_mtime
+        seven_days_ago = time() - 7 * 86400
+        if filestamp < seven_days_ago:
+            os.remove(file_path)
     return results, status_code
 
 

--- a/htsget_server/search.py
+++ b/htsget_server/search.py
@@ -22,6 +22,7 @@ def search_file(file_path):
             json_data = json.load(f)
         if json_data is not None:
             logger.info(f"Searching {file_path}")
+            results["result"] = full_beacon_search(json_data)
             results["complete"] = True
         os.remove(file_path)
     except Exception as e:

--- a/htsget_server/search.py
+++ b/htsget_server/search.py
@@ -1,0 +1,67 @@
+from config import SEARCH_PATH
+import os
+from watchdog.observers import Observer
+import watchdog.events
+from candigv2_logging.logging import initialize, CanDIGLogger
+import json
+from beacon_operations import full_beacon_search
+
+
+logger = CanDIGLogger(__file__)
+
+initialize()
+
+
+def search_file(file_path):
+    json_data = None
+    status_code = 500
+    results = {}
+    results_path = os.path.join(SEARCH_PATH, "results", os.path.basename(file_path))
+    try:
+        with open(file_path) as f:
+            json_data = json.load(f)
+        if json_data is not None:
+            logger.info(f"Searching {file_path}")
+            results["complete"] = True
+        os.remove(file_path)
+    except Exception as e:
+        message = f"Couldn't load data from {file_path}: {type(e)} {str(e)}"
+        logger.error(message)
+        results["error"] = message
+        status_code = 500
+    with open(results_path, "w") as f:
+        json.dump(results, f)
+    return results, status_code
+
+
+class SearchHandler(watchdog.events.FileSystemEventHandler):
+    def on_created(self, event):
+        search_file(event.src_path)
+
+
+if __name__ == "__main__":
+    ## look for any backlog IDs, search those, then listen for new IDs to search.
+    search_path = os.path.join(SEARCH_PATH, "to_search")
+    logger.info(f"searching started on {search_path}")
+    to_search = os.listdir(search_path)
+    logger.info(f"Finishing backlog: searching {to_search}")
+    while len(to_search) > 0:
+        try:
+            file_path = f"{search_path}/{to_search.pop()}"
+            search_file(file_path)
+        except Exception as e:
+            logger.warning(str(e))
+        to_search = os.listdir(search_path)
+
+    # now that the backlog is complete, listen for new files created:
+    logger.info(f"listening for new files at {search_path}")
+    event_handler = SearchHandler()
+    observer = Observer()
+    observer.schedule(event_handler, search_path, recursive=False)
+    observer.start()
+    try:
+        while observer.is_alive():
+            observer.join(1)
+    finally:
+        observer.stop()
+        observer.join()

--- a/htsget_server/search.sh
+++ b/htsget_server/search.sh
@@ -1,0 +1,9 @@
+until python htsget_server/search.py; do
+    status=$?
+    if [[ $status != 10 ]]; then
+        echo "Search crashed with exit code $status.  Respawning..." >&2
+    else
+        echo "search OFF"
+    fi
+    sleep 10
+done

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -8,19 +8,20 @@ from candigv2_logging.logging import CanDIGLogger
 logger = CanDIGLogger(__file__)
 
 
-def find_variants_in_region(reference_name=None, start=None, end=None):
-    """
-    finds variant records in vcf files, returns an array of VcfJson objects
-    """
-
+def find_variants_in_database(reference_name=None, start=None, end=None):
     region = {'referenceName': database.normalize_contig(reference_name)}
     if start is not None:
-        region['start'] = int(start) - 1 # search for bases starting at the interbase half-a-base back
+        region['start'] = start
     if end is not None:
-        region['end'] = int(end)
-    raw_result = database.search({
-        "region": region
-    })
+        region['end'] = end
+
+    return database.search({"region": region})
+
+
+"""
+finds variant records in vcf files, returns an array of VcfJson objects
+"""
+def find_variants_in_files(raw_result, reference_name=None, start=None, end=None):
     # raw_result = [{'drs_object_id', 'variantcount', 'reference_genome'}]
     # fetch all relevant results:
     #   group results by variant (chr:start-end)
@@ -28,8 +29,7 @@ def find_variants_in_region(reference_name=None, start=None, end=None):
     #   resultsets require more processing
     variants_by_file = {}
     for result in raw_result:
-        variants_by_file[result['drs_object_id']] = parse_vcf_file(result['drs_object_id'], reference_name=region['referenceName'], start=region['start'], end=region['end'])
-
+        variants_by_file[result['drs_object_id']] = parse_vcf_file(result['drs_object_id'], reference_name, start, end)
     # if a file has no variants in it, we don't need to return it:
     final_variants_by_file = {}
     for file in variants_by_file.keys():
@@ -44,7 +44,7 @@ def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None):
         raise Exception(f"error parsing vcf file for {drs_object_id}: {analysis_obj['message']}")
     if reference_name is not None:
         ref_name = database.get_contig_name_in_variantfile({'refname': reference_name, 'variantfile_id': drs_object_id})
-        records = analysis_obj['file'].fetch(contig=ref_name, start=start, end=end)
+        records = analysis_obj['file'].fetch(contig=ref_name, start=int(start), end=int(end))
     else:
         records = analysis_obj['file'].fetch()
     headers = parse_headers(database.get_headers({'variantfile_id': drs_object_id}))

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -15,7 +15,7 @@ LOCAL_FILE_PATH = os.path.abspath(f"{REPO_DIR}/data/files")
 SERVER_LOCAL_DATA = os.getenv("SERVER_LOCAL_DATA", "/app/htsget_server/data")
 
 HOST = os.getenv("TESTENV_URL")
-TEST_KEY = os.environ.get("HTSGET_TEST_KEY")
+TEST_KEY = os.getenv("HTSGET_TEST_KEY")
 USERNAME = os.getenv("CANDIG_NOT_ADMIN_USER2", "user2@test.ca")
 MINIO_URL = os.getenv("MINIO_URL")
 VAULT_URL = os.getenv("VAULT_URL")
@@ -473,6 +473,20 @@ def test_beacon_get_search():
     url = f"{HOST}/beacon/v2/g_variants?assemblyId=hg38&allele=NC_000021.9%3Ag.5030847T%3EA"
     response = requests.get(url, headers=get_headers())
     print(response.text)
+    assert len(response.json()['estimatedResults']["test-htsget"]) == 2
+
+    url = re.sub(r".+\/beacon\/v2", f"{HOST}/beacon/v2", response.json()['beaconResultUrl'])
+    response = requests.get(url, headers=get_headers())
+    tries = 0
+    while response.status_code != 201:
+        sleep(2)
+        response = requests.get(url, headers=get_headers())
+        print(response.json())
+        tries = tries + 1
+        if tries > 10:
+            print("search is taking too long")
+            assert False
+
     assert len(response.json()['response']) == 2
 
 
@@ -520,6 +534,19 @@ def test_beacon_post_search(body, count, cases):
 
     response = requests.post(url, json=body, headers=get_headers())
     print(response.text)
+
+    url = re.sub(r".+\/beacon\/v2", f"{HOST}/beacon/v2", response.json()['beaconResultUrl'])
+    response = requests.get(url, headers=get_headers())
+    tries = 0
+    while response.status_code != 201:
+        sleep(2)
+        response = requests.get(url, headers=get_headers())
+        print(response.json())
+        tries = tries + 1
+        if tries > 10:
+            print("search is taking too long")
+            assert False
+
     assert len(response.json()['response']) == count
     assert len(response.json()['response'][0]['caseLevelData']) == cases
 
@@ -538,6 +565,19 @@ def test_beacon_search_annotations():
         }
     }
     response = requests.post(url, json=body, headers=get_headers())
+
+    url = re.sub(r".+\/beacon\/v2", f"{HOST}/beacon/v2", response.json()['beaconResultUrl'])
+    response = requests.get(url, headers=get_headers())
+    tries = 0
+    while response.status_code != 201:
+        sleep(2)
+        response = requests.get(url, headers=get_headers())
+        print(response.json())
+        tries = tries + 1
+        if tries > 10:
+            print("search is taking too long")
+            assert False
+
     found_gene = False
     print(response.json())
     for var in response.json()['response']:


### PR DESCRIPTION
The response to a beacon search is now of the form: 

```
{
  "beaconResultUrl": "http://candig.docker.internal:5080/genomics/beacon/v2/result/7d3c60fa-2d1c-11f0-8973-0242ac120008",
  "estimatedResults": {
    "LOCAL-SYNTH_01": [
      {
        "submitter_sample_id": "LOCAL-SAMPLE_NULL_0001",
        "variant_count": 2
      },
      {
        "submitter_sample_id": "LOCAL-SAMPLE_NULL_0002",
        "variant_count": 2
      }
    ],
    "LOCAL-SYNTH_02": [
      {
        "submitter_sample_id": "LOCAL-SAMPLE_0062",
        "variant_count": 3
      },
      {
        "submitter_sample_id": "LOCAL-SAMPLE_0061",
        "variant_count": 3
      }
    ]
  },
  "estimatedSearchParameters": {
    "end": 5039999,
    "referenceName": "21",
    "start": 5030000
  },
  "meta": {
    "apiVersion": "1.0.0",
    "beaconId": "org.candig.htsget.beacon",
    "receivedRequestSummary": {
      "apiVersion": "1.0.0",
      "pagination": {
        "limit": 10,
        "skip": 0
      },
      "requestParameters": {
        "alt": "A",
        "assembly_id": "hg38",
        "end": 5030848,
        "genomic_allele_short_form": "NC_000021.9:g.5030847T>A",
        "ref": "T",
        "reference_genome": "hg38",
        "reference_name": "21",
        "start": 5030846
      },
      "requestedGranularity": "record",
      "requestedSchemas": [
        {
          "entityType": "genomicVariant",
          "schema": "ga4gh-beacon-variant-v2.0.0"
        }
      ]
    }
  }
}
```

where the beaconResultUrl should lead you to an asynchronously-generated full beacon search result, as before. The new quick response contains estimatedSearchParameters, showing the user the bucket regions searched, and estimatedResults, showing the samples the user has access to that contain variants in the region.

If the query service sends a service token, estimatedResults will always contain all matching hits, same as the query_info dict from before.

If the user is not authorized for any programs, the estimatedResults will have a boolean telling you if there are any potential results or not.