### PR TITLE
DIG-2008: drs analysis object has data download handover url

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -411,14 +411,14 @@ def get_drs_object(object_id, expand=False, tries=1):
     return None
 
 
-def list_drs_objects(program_id=None, sample_registration_id=None):
+def list_drs_objects(program_id=None, submitter_sample_id=None):
     with Session() as session:
-        if program_id is None and sample_registration_id is None:
+        if program_id is None and submitter_sample_id is None:
             result = session.query(DrsObject).all()
-        elif sample_registration_id is None: # searching for program
+        elif submitter_sample_id is None: # searching for program
             result = session.query(DrsObject).filter_by(program_id=program_id).all()
         else: # searching for experiments with sample registration IDs
-            result = session.query(DrsObject).filter_by(name=sample_registration_id).all()
+            result = session.query(DrsObject).filter_by(name=submitter_sample_id).all()
 
         if result is not None:
             new_obj = json.loads(str(result))

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -232,8 +232,8 @@ components:
           type: string
     SampleRegistrationQuery:
         in: query
-        name: sample_registration_id
-        description: sample_registration_id from mohccn data model
+        name: submitter_sample_id
+        description: submitter_sample_id from mohccn data model
         schema:
           type: string
     ObjectId:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -752,16 +752,18 @@ components:
             Until then, if implementors do choose such an algorithm (e.g. because it's implemented by their storage provider), they SHOULD use an existing
             standard `type` value such as `md5`, `etag`, `crc32c`, `trunc512`, or `sha1`.
           example: sha-256
-    LocalFileAccessMethod:
+    AccessUrlMethod:
       description: A full URL describing the file's location
       type: object
       required:
         - type
+        - access_url
       properties:
         type:
           type: string
           enum:
             - file
+            - download
         access_url:
           type: object
           required:
@@ -773,11 +775,12 @@ components:
               type: array
               items:
                 type: string
-    S3AccessMethod:
+    AccessIdMethod:
       description: An access id and region that might be needed to specify to get a signed URL for obtaining bytes
       type: object
       required:
         - type
+        - access_id
       properties:
         type:
           type: string
@@ -793,8 +796,8 @@ components:
           example: us-east-1
     AccessMethod:
       anyOf:
-        - $ref: '#/components/schemas/LocalFileAccessMethod'
-        - $ref: '#/components/schemas/S3AccessMethod'
+        - $ref: '#/components/schemas/AccessUrlMethod'
+        - $ref: '#/components/schemas/AccessIdMethod'
     AnalysisContentsObject:
       type: object
       required:

--- a/htsget_server/drs_openapi.yaml
+++ b/htsget_server/drs_openapi.yaml
@@ -453,9 +453,7 @@ components:
           description: The descriptor for this analysis data entity
         name:
           type: string
-          description: |-
-            The filename for this entity, not including its file extensions.
-            This string is made up of uppercase and lowercase letters, decimal digits, hypen, period, and underscore [A-Za-z0-9.-_]. See http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_282[portable filenames].
+          description: same as the id
         contents:
           type: array
           description: The specific analysis contents objects that comprise this analysis DRS entity. Should contain a AnalysisDataContentsObject, an optional AnalysisIndexContentsObject, and ExperimentContentsObjects corresponding to the experiments analyzed in the analysis data object.

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -74,8 +74,8 @@ def get_object_for_drs_uri(drs_uri):
     return {"message": f"Couldn't resolve DRS server {drs_uri_parse.group(1)}"}, 401
 
 
-def list_objects(program_id=None, sample_registration_id=None):
-    return database.list_drs_objects(program_id=program_id, sample_registration_id=sample_registration_id), 200
+def list_objects(program_id=None, submitter_sample_id=None):
+    return database.list_drs_objects(program_id=program_id, submitter_sample_id=submitter_sample_id), 200
 
 
 @app.route('/ga4gh/drs/v1/objects/<object_id>/access_url/<path:access_id>')

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -54,6 +54,14 @@ def get_object(object_id, expand=False):
             return {"message": f"Not authorized to access object {object_id}"}, auth_code
     if new_object is None:
         return {"message": "No matching object found"}, 404
+    if "access_methods" in new_object:
+        download_method = {
+            "access_url": {
+                "url": f"{HTSGET_URL}/ga4gh/drs/v1/objects/{object_id}/download"
+            },
+            "type": "download"
+        }
+        new_object["access_methods"].append(download_method)
     return new_object, 200
 
 

--- a/htsget_server/drs_operations.py
+++ b/htsget_server/drs_operations.py
@@ -95,10 +95,10 @@ def download_file(object_id, request=connexion.request):
             if drs_object["metadata"]["analysis_type"] == "reference_alignment":
                 return {"message": f"Sorry, read files are not allowed to be downloaded"}, 403
     for method in drs_object["access_methods"]:
-        if "access_url" in method:
+        if "access_url" in method and method["type"] == "file":
             file_obj = _get_file_path(drs_object["id"])
             return send_file(file_obj["path"]), 200
-        else:
+        elif "access_id" in method:
             url, status_code = _get_access_url(method["access_id"])
             r = requests.get(url["url"], stream=True)
             return Response(r.iter_content(chunk_size=10*1024), content_type=r.headers['Content-Type'])
@@ -323,7 +323,7 @@ def _get_file_path(drs_file_obj_id):
                 }
                 result["size"] = url_obj["metadata"].size
                 break
-        else:
+        elif method["type"] == "file":
             # the access_url has all the info we need
             url_pieces = urlparse(method["access_url"]["url"])
             if url_pieces.scheme == "file":


### PR DESCRIPTION
To get a download url from a sample + program:
* GET list of relevant objects: `http://candig.docker.internal:5080/genomics/ga4gh/drs/v1/objects?program_id=LOCAL-SYNTH_02&submitter_sample_id=LOCAL-SAMPLE_0061` gives you the matching Experiment objects.
* The contents of the Experiment object are the linked Analyses: use the `name` of the analysis to get the AnalysisDrsObject with `GET http://candig.docker.internal:5080/genomics/ga4gh/drs/v1/objects/<analysis_drs_obj_id>`.
* The AnalysisDrsObject will include the relevant files in its list of contents. The main file will have id `analysis`, and there might also be one of id `index`. Use the `name` of each of them to get the files' drs objects. `GET http://candig.docker.internal:5080/genomics/ga4gh/drs/v1/objects/<analysis_file_name>` will contain an access method of type `download`. That is your direct download URL.