### PR TITLE
Hotfix: make sure that the queue_id is a uuid

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -319,8 +319,11 @@ def add_to_queue(ingest_json):
 
 @app.route('/beacon/v2/result/<path:queue_id>')
 def get_full_result(queue_id):
+    uuid_match = re.match(r"^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$", queue_id)
+    if uuid_match is None:
+        return {"error": f"queue_id {queue_id} is not a UUID"}
     try:
-        results_path = os.path.join(SEARCH_PATH, "results", queue_id)
+        results_path = os.path.join(SEARCH_PATH, "results", uuid_match.group(0))
         with open(results_path) as f:
             json_data = json.load(f)
             # os.remove(results_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.1.0
+Flask==3.1.1
 Flask-Cors==5.0.0
 minio==7.2.12
 pysam==0.22.0


### PR DESCRIPTION
Snyk alerted me to this vulnerability: we should make sure that the user is not just passing an arbitrary string in as a UUID, since it does go into a path.

I also bumped Flask's version.