### PR TITLE
hotfix: remove deprecated packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN groupadd -r candig && useradd -rm candig -g candig
 
 RUN apt-get update && apt-get -y install \
 	cron \
-	libpcre3  \
-	libpcre3-dev \
 	sqlite3 \
 	postgresql-client \
     postgresql


### PR DESCRIPTION
Seems like Debian has removed the libpcre3 packages, so building fails on getting those packages. It doesn't seem like they're actually required anymore, probably because whatever required these EOL'ed packages no longer does.