### PR TITLE
DIG-2086: specify fullSearch=true to enable full search

### DIFF
--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -206,7 +206,7 @@ components:
     fullSearch:
       in: query
       name: fullSearch
-      description: Set to true if a full beacon search is desired.
+      description: Set to true if a full beacon search is desired; default is to return estimated variant count.
       schema:
         type: boolean
     geneId:

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -147,6 +147,7 @@ paths:
         - $ref: '#/components/parameters/genomicAlleleShortForm'
         - $ref: '#/components/parameters/geneId'
         - $ref: '#/components/parameters/filters'
+        - $ref: '#/components/parameters/fullSearch'
       responses:
         '200':
           $ref: '#/components/responses/ResultsOKResponse'
@@ -202,6 +203,12 @@ components:
         type: array
         items:
           type: string
+    fullSearch:
+      in: query
+      name: fullSearch
+      description: Set to true if a full beacon search is desired.
+      schema:
+        type: boolean
     geneId:
       example: BRAF
       in: query
@@ -709,6 +716,9 @@ components:
         - requestedGranularity
     RequestParameters:
       properties:
+        fullSearch:
+          description: Set to true if full search of files is desired
+          type: boolean
         alternateBases:
           $ref: '#/components/schemas/AlternateBases'
         aminoacidChange:

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -80,7 +80,8 @@ def get_search(
     variant_max_length=None,
     allele=None,
     gene_id=None,
-    filters=None
+    filters=None,
+    full_search=False
 ):
     req = {
         "includeResultsetResponses": include_result_set_responses,
@@ -115,6 +116,8 @@ def get_search(
         req['query']['requestParameters']['variant_max_length'] = variant_max_length
     if variant_min_length is not None:
         req['query']['requestParameters']['variant_min_length'] = variant_min_length
+    if full_search:
+        req['query']['requestParameters']['full_search'] = True
 
     try:
         result = search(req)
@@ -274,8 +277,11 @@ def search(raw_req):
             "meta": meta,
             "authed_programs": authed_programs
         }
-        queue_id = add_to_queue(search_json)
-        response["beaconResultUrl"] = f"{HTSGET_URL}/beacon/v2/result/{queue_id}"
+
+        # only send to queue if a full search was requested:
+        if 'full_search' in actual_params and actual_params['full_search'] == True:
+            queue_id = add_to_queue(search_json)
+            response["beaconResultUrl"] = f"{HTSGET_URL}/beacon/v2/result/{queue_id}"
 
         # set up quick beacon results:
         response["estimatedSearchParameters"] = {


### PR DESCRIPTION
To test: do a beacon search either through the GET or POST endpoints. If you specify `fullSearch=true`, you should see a `beaconResultUrl` in the result; if you don't, it shouldn't be there.

```
curl "http://candig.docker.internal:5080/genomics/beacon/v2/g_variants?assemblyId=hg38&geneId=TP53&fullSearch=true" \
     -H 'Authorization: Bearer <token>'  
``` 
or
```
curl -X "POST" "http://candig.docker.internal:5080/genomics/beacon/v2/g_variants" \
     -H 'Authorization: Bearer <token>' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "query": {
    "requestParameters": {
      "gene_id": "SLC2A5",
      "fullSearch": true
    }
  },
  "meta": {
    "apiVersion": "v2"
  }
}'
```