### PR TITLE
Miscellaneous indexing fixes

### DIFF
--- a/htsget_server/database.py
+++ b/htsget_server/database.py
@@ -575,6 +575,13 @@ def create_pos_buckets_for_variantfile(obj):
         session.bulk_insert_mappings(PositionBucketVariantFileAssociation, pbvfs_to_add)
         session.commit()
 
+    with Session() as session:
+        new_variantfile = session.query(VariantFile).filter_by(id=variantfile_id).one_or_none()
+        if new_variantfile is not None:
+            new_variantfile.indexed = 1
+            session.add(new_variantfile)
+            session.commit()
+
     return None
 
 

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -352,8 +352,8 @@ def _get_experiment(id_=None):
                     elif drs_obj["type"] == "read":
                         result["reads"].append(drs_obj["name"])
             return result, 200
-    else:
-        return resp.text, resp.status_code
+        return f"{id_} is not an Experiment", 404
+    return resp.text, resp.status_code
 
 
 def _get_htsget_url(id, reference_name, slice_start, slice_end, file_type, data=True):


### PR DESCRIPTION
If you run a genomic query, part of the query operation tries to look up every drs object ID as if it is an experiment. This is a separate problem that I need to work on for https://candig.atlassian.net/browse/DIG-2136. However, because it is doing all of these erroneous htsget lookups, it is causing a 500 error because I didn't catch the "this object is valid but not an experiment" case correctly. This PR fixes that.

It also makes sure that the indexed flag gets set in the variantfile database; I thought it was but I guess I missed it?

This is currently deployed on UHN-prod and indexing seems to be going fine there now.