### PR TITLE
DIG-2150: fix parsing of headers

### DIFF
--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -855,12 +855,12 @@ components:
                 program:
                     type: string
                     description: MoH program ID
-                genome:
+                genomes:
                     type: array
                     description: An array of associated AnalysisDrsObjects that describe reads, e.g. fastqs.
                     items:
                         type: string
-                transcriptome:
+                transcriptomes:
                     type: array
                     description: An array of associated AnalysisDrsObjects that describe transcriptome data.
                     items:

--- a/htsget_server/variants.py
+++ b/htsget_server/variants.py
@@ -51,8 +51,7 @@ def parse_vcf_file(drs_object_id, reference_name=None, start=None, end=None, hea
         records = analysis_obj['file'].fetch(contig=ref_name, start=int(start), end=int(end))
     else:
         records = analysis_obj['file'].fetch()
-    headers = parse_headers(database.get_headers({'variantfile_id': drs_object_id}))
-
+    headers = parse_headers(str(analysis_obj['file'].header).split("\n"))
     variants_by_file = {
         "id": drs_object_id,
         "headers": headers,

--- a/tests/test_htsget_server.py
+++ b/tests/test_htsget_server.py
@@ -317,14 +317,13 @@ def test_add_experiment_drs(experiment, analysis):
 def test_experiment_stats(experiment, analysis):
     headers = get_headers()
 
-    experiment = experiment['experiment_id']
     # look for the experiment
-    get_url = f"{HOST}/htsget/v1/experiments/{experiment}"
+    get_url = f"{HOST}/htsget/v1/experiments/{experiment['submitter_sample_id']}"
     response = requests.request("GET", get_url, headers=headers)
     assert response.status_code == 200
 
-    # genomes in a program will be experiments, which are listed by sample_registration_id
-    assert experiment in response.json()['genomes']
+    # genomes in a program will be experiments, which are listed by experiment_id
+    assert experiment['experiment_id'] in response.json()['genomes']
 
 
 def test_program_experiments():


### PR DESCRIPTION
Grab the headers from the pysam object instead of the database. Also tweak the experiments tests to match latest.

To test: run `docker exec candigv2_htsget_1 pytest`