### PR TITLE
Bugfix: only count known variants

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -272,13 +272,14 @@ def search(raw_req):
         hits_to_search = []
         for i in range(len(potential_hits)):
             drs_obj_id = potential_hits[i]['drs_object_id']
-            experiments = exp_lookup[drs_obj_id]
-            for experiment in experiments:
-                if experiment["program"] not in results:
-                    results[experiment["program"]] = []
-                res = {"submitter_sample_id": experiment["experiment_id"], "variant_count": potential_hits[i]["variantcount"]}
-                results[experiment["program"]].append(res)
-                hits_to_search.append(potential_hits[i])
+            if drs_obj_id in exp_lookup:
+                experiments = exp_lookup[drs_obj_id]
+                for experiment in experiments:
+                    if experiment["program"] not in results:
+                        results[experiment["program"]] = []
+                    res = {"submitter_sample_id": experiment["experiment_id"], "variant_count": potential_hits[i]["variantcount"]}
+                    results[experiment["program"]].append(res)
+                    hits_to_search.append(potential_hits[i])
 
         search_json = {
             "potential_hits": hits_to_search,


### PR DESCRIPTION
All vcf files will be indexed because the indexer actually looks at the file type of the file itself (line 638 of htsget_operations.py), but if the metadata is wrong, for example, categorizing a vcf file as a transcriptome:

```
  "metadata": {
    "analysis_attribute": {
      "subtype": "mutation"
    },
    "analysis_type": "sequence_annotation",
    "reference": "hg38"
  },
```

we can get a key error where the variantfile that was indexed is present in the search hits, but the AnalysisDrsObject is not classed as a variant. 

Probably the ideal solution is to prevent this sort of mismatched metadata from getting into the system, but in the meantime this fix prevents an error from being thrown in case something like this happens.