### PR TITLE
DIG-2209: change drs experiment to biosample

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -253,32 +253,33 @@ def search(raw_req):
             raise Exception(f"exception in search for {actual_params}: {type(e)} {str(e)}")
 
         results = {}
-        # look for experiments and programs for all drs objects, even if user is not authorized
+        # look for biosamples and programs for all drs objects, even if user is not authorized
         headers = {
             "X-Service-Token": create_service_token()
         }
-        resp = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/experiments", headers=headers, json={})
+        resp = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/biosamples", headers=headers, json={})
 
-        exp_lookup = {}
+        biosample_lookup = {}
         if resp.status_code == 200:
-            for exp in resp.json():
-                for v in exp["variants"]:
-                    if v not in exp_lookup:
-                        exp_lookup[v] = []
-                    exp_lookup[v].append(exp)
+            for biosample in resp.json():
+                if "sequence_variation" in biosample["analyses"]:
+                    for v in biosample["analyses"]["sequence_variation"]:
+                        if v not in biosample_lookup:
+                            biosample_lookup[v] = []
+                        biosample_lookup[v].append(biosample)
         else:
-            raise Exception(f"couldn't get experiments: {resp.text} {resp.status_code}")
+            raise Exception(f"couldn't get biosamples: {resp.text} {resp.status_code}")
 
         hits_to_search = []
         for i in range(len(potential_hits)):
             drs_obj_id = potential_hits[i]['drs_object_id']
-            if drs_obj_id in exp_lookup:
-                experiments = exp_lookup[drs_obj_id]
-                for experiment in experiments:
-                    if experiment["program"] not in results:
-                        results[experiment["program"]] = []
-                    res = {"submitter_sample_id": experiment["experiment_id"], "variant_count": potential_hits[i]["variantcount"]}
-                    results[experiment["program"]].append(res)
+            if drs_obj_id in biosample_lookup:
+                biosamples = biosample_lookup[drs_obj_id]
+                for biosample in biosamples:
+                    if biosample["program"] not in results:
+                        results[biosample["program"]] = []
+                    res = {"submitter_sample_id": biosample["biosample_id"], "variant_count": potential_hits[i]["variantcount"]}
+                    results[biosample["program"]].append(res)
                     hits_to_search.append(potential_hits[i])
 
         search_json = {
@@ -425,7 +426,7 @@ def full_beacon_search(search_json, headers=None):
     }
 
     for drs_obj_id in variants_by_file.keys():
-        # look for experiments and programs for all drs objects, even if user is not authorized
+        # look for biosamples and programs for all drs objects, even if user is not authorized
         resp = requests.get(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj_id}", headers=headers)
         if resp.status_code == 200:
             drs_obj = resp.json()

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -370,11 +370,11 @@ paths:
                                 type: object
                                 $ref: '#/components/schemas/GeneSearchResultsTicket'
 
-    /experiments/{id}:
+    /biosamples/{id}:
         get:
-            summary: Get metadata about a experiment
-            operationId: htsget_operations.get_experiment
-            description: Get MoH-relevant genomic information about an experiment
+            summary: Get metadata about a biosample
+            operationId: htsget_operations.get_biosample
+            description: Get MoH-relevant genomic information about an biosample
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
                 - $ref: "#/components/parameters/sampleIdPathParam"
@@ -384,12 +384,12 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ExperimentTicket'
-    /experiments:
+                                $ref: '#/components/schemas/BiosampleTicket'
+    /biosamples:
         get:
-            summary: Get metadata about experiments in a program
-            operationId: htsget_operations.get_program_experiments
-            description: Get MoH-relevant genomic information about all experiments in a program
+            summary: Get metadata about biosamples in a program
+            operationId: htsget_operations.get_program_biosamples
+            description: Get MoH-relevant genomic information about all biosamples in a program
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
                 - $ref: '#/components/parameters/programParam'
@@ -401,15 +401,15 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/ExperimentTicket'
+                                    $ref: '#/components/schemas/BiosampleTicket'
         post:
-            summary: Get metadata about multiple experiments
-            operationId: htsget_operations.get_multiple_experiments
-            description: Get MoH-relevant genomic information about a list of experiments
+            summary: Get metadata about multiple biosamples
+            operationId: htsget_operations.get_multiple_biosamples
+            description: Get MoH-relevant genomic information about a list of biosamples
             parameters:
                 - $ref: '#/components/parameters/authHeaderParam'
             requestBody:
-                $ref: '#/components/requestBodies/ExperimentsRequestBody'
+                $ref: '#/components/requestBodies/BiosamplesRequestBody'
             responses:
                 200:
                     description: Success
@@ -418,7 +418,7 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/ExperimentTicket'
+                                    $ref: '#/components/schemas/BiosampleTicket'
 
 tags:
     - name: Reads
@@ -846,36 +846,30 @@ components:
                                                 - hg38
                                         region:
                                             $ref: '#/components/schemas/Region'
-        ExperimentTicket:
+        BiosampleTicket:
             type: object
             properties:
-                experiment_id:
+                biosample_id:
                     type: string
                     description: MoH submitter_sample_id from a Sample Registration associated with a specimen.
                 program:
                     type: string
                     description: MoH program ID
-                genomes:
+                experiments:
                     type: array
-                    description: An array of associated AnalysisDrsObjects that describe reads, e.g. fastqs.
+                    description: An array of associated ExperimentDrsObjects derived from the biosample.
                     items:
                         type: string
-                transcriptomes:
+                runs:
                     type: array
-                    description: An array of associated AnalysisDrsObjects that describe transcriptome data.
+                    description: An array of associated RunDrsObjects that describe raw reads derived from biosample.
                     items:
                         type: string
-                variants:
+                analyses:
                     type: array
-                    description: An array of associated AnalysisDataDrsObjects that describe variant files.
+                    description: An array of associated AnalysisDrsObjects based on the biosample.
                     items:
                         type: string
-                reads:
-                    type: array
-                    description: An array of associated AnalysisDataDrsObjects that describe read files, e.g. bams.
-                    items:
-                        type: string
-
 
         # ERROR SCHEMAS
         Error:
@@ -1083,15 +1077,15 @@ components:
                 application/json:
                     schema:
                         $ref: '#/components/schemas/ReadsRequestBody'
-        ExperimentsRequestBody:
-            description: List of experiments requested
+        BiosamplesRequestBody:
+            description: List of biosamples requested
             required: false
             content:
                 application/json:
                     schema:
                         type: object
                         properties:
-                            experiments:
+                            biosamples:
                                 type: array
                                 items:
                                     type: string

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -236,31 +236,31 @@ def get_matching_transcripts(id_=None):
     return get_matching_genes(id_=id_, type="transcript_name")
 
 
-@app.route('/experiments/<path:id_>')
-def get_experiment(id_=None):
+@app.route('/biosamples/<path:id_>')
+def get_biosample(id_=None):
     if not authz.has_full_authz(connexion.request):
-        return {"message": "User is not authorized to get experiments"}, 403
-    result, status_code = _get_experiment(id_)
+        return {"message": "User is not authorized to get biosamples"}, 403
+    result, status_code = _get_biosample(id_)
     if status_code == 200:
         return result, 200
-    return {"message": f"Could not get experiment {id_}: {result}"}, status_code
+    return {"message": f"Could not get biosample {id_}: {result}"}, status_code
 
 
-async def get_multiple_experiments():
+async def get_multiple_biosamples():
     if not authz.has_full_authz(connexion.request):
-        return {"message": "User is not authorized to get experiments"}, 403
+        return {"message": "User is not authorized to get biosamples"}, 403
     req = await connexion.request.json()
-    if "experiments" in req:
-        return _get_experiments(req["experiments"]), 200
-    return _get_experiments(None), 200
+    if "biosamples" in req:
+        return _get_biosamples(req["biosamples"]), 200
+    return _get_biosamples(None), 200
 
-def get_program_experiments(program=None):
+def get_program_biosamples(program=None):
     if not authz.has_full_authz(connexion.request):
-        return {"message": "User is not authorized to get experiments"}, 403
-    experiments = _get_experiments(None, program=program)
-    if len(experiments) > 0:
-        return experiments, 200
-    return {"message": f"No experiments found for {program}"}, 404
+        return {"message": "User is not authorized to get biosamples"}, 403
+    biosamples = _get_biosamples(None, program=program)
+    if len(biosamples) > 0:
+        return biosamples, 200
+    return {"message": f"No biosamples found for {program}"}, 404
 
 
 # This is specific to our particular use case: a DRS object that represents a
@@ -303,48 +303,39 @@ def get_pysam_obj(object_id, headers=None):
     return result
 
 
-def _get_experiments(experiments, program=None):
+def _get_biosamples(biosamples, program=None):
     result = []
     headers = {
         "X-Service-Token": create_service_token()
     }
-    if experiments is None:
-        resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/experiments", headers=headers, json={})
+    if biosamples is None:
+        resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/biosamples", headers=headers, json={})
     else:
-        resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/experiments", headers=headers, json={"submitter_sample_ids": experiments})
+        resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/biosamples", headers=headers, json={"submitter_sample_ids": biosamples})
     if resp.status_code == 200:
-        experiments_by_program = {}
+        biosamples_by_program = {}
         for res in resp.json():
-            if res["program"] not in experiments_by_program:
-                experiments_by_program[res["program"]] = []
-            experiments_by_program[res["program"]].append(res)
+            if res["program"] not in biosamples_by_program:
+                biosamples_by_program[res["program"]] = []
+            biosamples_by_program[res["program"]].append(res)
         if program is not None:
-            if program in experiments_by_program:
-                return experiments_by_program[program]
+            if program in biosamples_by_program:
+                return biosamples_by_program[program]
             return result
-        for program in experiments_by_program.keys():
-            result.extend(experiments_by_program[program])
+        for program in biosamples_by_program.keys():
+            result.extend(biosamples_by_program[program])
     return result
 
 
-def _get_experiment(id_=None):
-    result = {
-        "experiment_id": id_,
-        "genomes": [],
-        "transcriptomes": [],
-        "variants": [],
-        "reads": []
-    }
-
-    # Get the ExperimentDrsObject. It will have a contents array of AnalysisContentsObjects > AnalysisDrsObjects.
+def _get_biosample(id_=None):
     headers = {
         "X-Service-Token": create_service_token()
     }
-    resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/experiments", headers=headers, json={"submitter_sample_ids": [id_]})
+    resp = requests.post(f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/biosamples", headers=headers, json={"submitter_sample_ids": [id_]})
 
     if resp.status_code == 200:
         if len(resp.json()) == 0:
-            return f"{id_} is not an Experiment", 404
+            return f"{id_} is not an Biosample", 404
         return resp.json().pop(), 200
     return resp.text, resp.status_code
 


### PR DESCRIPTION
Updating use of /experiments to /biosamples to match https://github.com/CanDIG/drs-service/pull/15. Most changes are just a straight replacement for the new DRS endpoint; there are also a few formatting updates for beacon.

Testing should be performed in https://github.com/CanDIG/CanDIGv2/pull/1252.