### PR TITLE
Skip auth when the request is from candig-api

### DIFF
--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -302,7 +302,7 @@ def search(raw_req):
         }
 
         response["estimatedResults"] = {}
-        if authz.request_is_from_query(connexion.request):
+        if authz.request_is_from_query(connexion.request) or authz.request_is_from_candig_api(connexion.request):
             response["estimatedResults"] = results
         elif len(authed_programs) > 0:
             for program in authed_programs:


### PR DESCRIPTION
This does the same logic for skipping auth when figuring out what to serve that we did with Query, but for candig-api