### PR TITLE
make sure that an indexed analysis has an analysis date, if available

### DIFF
--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -163,6 +163,9 @@ def index_analysis(id_=None, force=False, genome='hg38'):
                             drs_obj["drs_obj"]["metadata"] = {}
                         if "indexed" not in drs_obj["drs_obj"]["metadata"]:
                             drs_obj["drs_obj"]["metadata"]["indexed"] = 1
+                            # make sure any analysis_date we found in the headers during indexing is in the drs_object
+                            if "analysis_date" not in drs_obj["drs_obj"]["metadata"] and "analysis_date" in varfile:
+                                drs_obj["drs_obj"]["metadata"]["analysis_date"] = varfile["analysis_date"]
                             resp = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects", headers=headers, json=drs_obj["drs_obj"])
                         return varfile, 200
             Path(f"{INDEXING_PATH}/{program}~{id_}").touch()


### PR DESCRIPTION
We found a bug while testing https://github.com/CanDIG/CanDIGv2/pull/1293.

If an object is ingested and no analysis_date is provided in the ingest metadata, htsget looks for an analysis date while indexing the file. This date is then written back out to the analysis object's metadata. To test that this works, we included two analyses in the test ingest file that have analysis dates in the vcf headers, but do not specify analysis dates in the ingest metadata.

However, our tests ingest the same ingest file twice. On the second time, these analyses are noted as being indexed already, so they are not indexed again. We need to make sure that the analysis date that was recorded on the previous indexing is actually propagated back to the analysis metadata, as well as the indexed flag.

Integration tests should fail on test_analysis_dates without this fix, but succeed with this fix.