### PR TITLE
DIG-2308: include listen path in openapi

### DIFF
--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -9,7 +9,7 @@ info:
   version: '2.0.0'
 openapi: 3.0.2
 servers:
-- url: /genomics/beacon/v2
+- url: https://your-candig-domain/genomics/beacon/v2
 paths:
   /service-info:
     get:

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -9,7 +9,7 @@ info:
   version: '2.0.0'
 openapi: 3.0.2
 servers:
-- url: /beacon/v2
+- url: /genomics/beacon/v2
 paths:
   /service-info:
     get:

--- a/htsget_server/beacon_openapi.yaml
+++ b/htsget_server/beacon_openapi.yaml
@@ -13,6 +13,7 @@ servers:
 paths:
   /service-info:
     get:
+      summary: Get information about the beacon
       description: Get information about the beacon using GA4GH ServiceInfo format
       operationId: beacon_operations.get_beacon_service_info
       responses:
@@ -117,6 +118,7 @@ paths:
         schema:
           type: string
     get:
+      summary: Get full Beacon result for a search
       description: Get full Beacon result for a search
       operationId: beacon_operations.get_full_result
       responses:
@@ -130,6 +132,7 @@ paths:
           description: Not Found
   /g_variants:
     get:
+      summary: Search for variants
       description: Search for variants
       operationId: beacon_operations.get_search
       parameters:

--- a/htsget_server/beacon_operations.py
+++ b/htsget_server/beacon_operations.py
@@ -440,7 +440,7 @@ def full_beacon_search(search_json, headers=None):
                             file_drs_obj = resp.json()
                             download_handover = {
                                 'handoverType': {'id': 'CUSTOM', 'label': 'DOWNLOAD'},
-                                'url': f"{HTSGET_URL}/ga4gh/drs/v1/objects/{file_drs_obj['id']}/download"
+                                'url': f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{file_drs_obj['id']}/download"
                             }
                             if 'size' in file_drs_obj:
                                 download_handover['size'] = file_drs_obj['size']

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -26,6 +26,7 @@ paths:
     /indexer:
         get:
             operationId: "htsget_operations.indexer_status"
+            summary: Get the status of the indexer
             description: Get the status of the indexer
             responses:
                 200:
@@ -36,6 +37,7 @@ paths:
                                 type: object
         post:
             operationId: "htsget_operations.indexer_switch"
+            summary: Set the indexer on or off
             description: Set the indexer on or off
             parameters:
                 - in: query

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -3,7 +3,7 @@ info:
     version: 1.2.0
     title: candig htsget
 servers:
-  - url: /htsget/v1
+  - url: /genomics/htsget/v1
 paths:
     /reads/service-info:
        get:

--- a/htsget_server/htsget_openapi.yaml
+++ b/htsget_server/htsget_openapi.yaml
@@ -3,7 +3,7 @@ info:
     version: 1.2.0
     title: candig htsget
 servers:
-  - url: /genomics/htsget/v1
+  - url: https://your-candig-domain/genomics/htsget/v1
 paths:
     /reads/service-info:
        get:

--- a/htsget_server/server.py
+++ b/htsget_server/server.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 candigv2_logging.logging.initialize()
 
 # Create the application instance
-app = connexion.App(__name__, specification_dir='./')
+app = connexion.FlaskApp(__name__, specification_dir='./')
 CORS(app.app)
 
 app.add_api('htsget_openapi.yaml', pythonic_params=True)


### PR DESCRIPTION
Includes the /genomics part in the url in the openapi servers.

Also fixes a misspecified url for the drs download endpoint and updates the connexion app instantiation to match the docs.