### PR TITLE
Hotfix: move failed indexing files to a separate directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN groupadd -r candig && useradd -rm candig -g candig
 
 RUN apt-get update && apt-get -y install \
 	cron \
+	vim \
 	postgresql-client \
   postgresql
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ if [[ -f "initial_setup" ]]; then
     sed -i s@\<POSTGRES_USERNAME\>@$POSTGRES_USERNAME@ config.ini
 
     mkdir -p $INDEXING_PATH
+    mkdir -p $FAILURE_PATH
     mkdir -p $SEARCH_PATH/results
     mkdir -p $SEARCH_PATH/to_search
     touch $INDEXING_SWITCH_FILE

--- a/htsget_server/config.py
+++ b/htsget_server/config.py
@@ -36,5 +36,6 @@ if os.getenv("DEBUG_MODE", "1") == "1":
     DEBUG_MODE = True
 
 INDEXING_PATH = os.getenv("INDEXING_PATH", "~/tmp/indexing")
+FAILURE_PATH = os.getenv("FAILURE_PATH", "~/tmp/failed")
 SEARCH_PATH = os.getenv("SEARCH_PATH", "~/tmp/search")
 INDEXING_SWITCH_FILE = os.getenv("INDEXING_SWITCH_FILE", "~/indexing_on")

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -167,7 +167,7 @@ def index_touch_file(file_path):
 
     except Exception as e:
         write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} {str(e)}")
-        os.renames(file_path, file_path.replace(INDEXING_PATH, FAILURE_PATH))
+        os.rename(file_path, file_path.replace(INDEXING_PATH, FAILURE_PATH))
         logger.warning(f"indexing error! {type(e)} {str(e)}")
 
 

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -1,6 +1,6 @@
 import htsget_operations
 import database
-from config import INDEXING_PATH, INDEXING_SWITCH_FILE
+from config import INDEXING_PATH, INDEXING_SWITCH_FILE, FAILURE_PATH
 import os
 import sys
 from watchdog.observers import Observer
@@ -167,6 +167,7 @@ def index_touch_file(file_path):
 
     except Exception as e:
         write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} {str(e)}")
+        os.renames(file_path, file_path.replace(INDEXING_PATH, FAILURE_PATH))
         logger.warning(f"indexing error! {type(e)} {str(e)}")
 
 

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -66,19 +66,22 @@ def index_variants(drs_obj_id, service_headers, program):
     positions = []
     normalized_contigs = []
     to_create = {'variantfile_id': drs_obj_id, 'positions': positions, 'normalized_contigs': normalized_contigs}
-    for record in gen_obj['file'].fetch():
-        normalized_contig_id = contigs[record.contig]
-        if normalized_contig_id is not None:
-            positions.append(record.pos)
-            normalized_contigs.append(normalized_contig_id)
-        else:
-            logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
-    res = create_position(to_create)
+    try:
+        for record in gen_obj['file'].fetch():
+            normalized_contig_id = contigs[record.contig]
+            if normalized_contig_id is not None:
+                positions.append(record.pos)
+                normalized_contigs.append(normalized_contig_id)
+            else:
+                logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
+        res = create_position(to_create)
 
-    logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
-    write_pos_bucket(res, drs_obj_id)
-    mark_as_indexed(drs_obj_id, service_headers)
-    logger.info(f"{drs_obj_id} indexing done")
+        logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+        write_pos_bucket(res, drs_obj_id)
+        mark_as_indexed(drs_obj_id, service_headers)
+        logger.info(f"{drs_obj_id} indexing done")
+    except Exception as e:
+        raise Exception(f"({type(e)} {str(e)}) got as far as {normalized_contigs[-1]} {positions[-1]} in {drs_obj_id}")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 


### PR DESCRIPTION
Small hotfix: if a file fails to index, move the stub file from /home/candig/tmp/indexer to /home/candig/tmp/failed, so that it won't try indexing it again on restart.

Tested in https://github.com/CanDIG/CanDIGv2/pull/1370
