### PR TITLE
DIG-2363: fix indexing file streaming errors

### DIFF
--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -9,7 +9,6 @@ from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH, IND
 from markupsafe import escape
 import connexion
 import variants
-import indexing
 from pathlib import Path
 from candigv2_logging.logging import CanDIGLogger
 from pysam import VariantFile, AlignmentFile, FastxFile

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -28,6 +28,8 @@ def index_variants(drs_obj_id, service_headers, program):
 
     if gen_obj['type'] == 'read':
         return {"message": f"Read object {drs_obj_id} stats calculated"}, 200
+    if gen_obj['type'] == 'fastx':
+        return {"message": f"Fastx object {drs_obj_id} stats calculated"}, 200
 
     logger.info(f"{drs_obj_id} starting indexing")
     write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} starting indexing")

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -192,32 +192,34 @@ def write_index_status(drs_obj_id, headers, message):
 
 @contextmanager
 def get_local_variantfile(drs_obj_id, headers):
-    drs_obj = htsget_operations._describe_drs_object(drs_obj_id, headers=headers)
-
-    # download the main file
-    main_file = tempfile.NamedTemporaryFile(delete=False)
-    with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['main']}/download", headers=headers) as response:
-        response.raise_for_status()
-        total_size = int(response.headers.get("content-length", 0))
-        with (open(main_file.name, "wb") as f):
-            for chunk in response.iter_raw():
-                bytes_written = f.write(chunk)
-        main_file.close()
-
-    # download the index file
-    index_file = tempfile.NamedTemporaryFile(delete=False)
-    with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['index']}/download", headers=headers) as response:
-        response.raise_for_status()
-        total_size = int(response.headers.get("content-length", 0))
-        with (open(index_file.name, "wb") as f):
-            for chunk in response.iter_raw():
-                bytes_written = f.write(chunk)
-        index_file.close()
-
-    var_obj = VariantFile(main_file.name, index_filename=index_file.name)
-
     try:
+        drs_obj = htsget_operations._describe_drs_object(drs_obj_id, headers=headers)
+
+        # download the main file
+        main_file = tempfile.NamedTemporaryFile(delete=False)
+        with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['main']}/download", headers=headers) as response:
+            response.raise_for_status()
+            total_size = int(response.headers.get("content-length", 0))
+            with (open(main_file.name, "wb") as f):
+                for chunk in response.iter_raw():
+                    bytes_written = f.write(chunk)
+            main_file.close()
+
+        # download the index file
+        index_file = tempfile.NamedTemporaryFile(delete=False)
+        with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['index']}/download", headers=headers) as response:
+            response.raise_for_status()
+            total_size = int(response.headers.get("content-length", 0))
+            with (open(index_file.name, "wb") as f):
+                for chunk in response.iter_raw():
+                    bytes_written = f.write(chunk)
+            index_file.close()
+
+        var_obj = VariantFile(main_file.name, index_filename=index_file.name)
+
         yield var_obj
+    except Exception as e:
+        write_index_status(drs_obj_id, headers, f"{type(e)} {str(e)}")
     finally:
         var_obj.close()
         os.remove(main_file.name)

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -199,7 +199,6 @@ def get_local_variantfile(drs_obj_id, headers):
         main_file = tempfile.NamedTemporaryFile(delete=False)
         with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['main']}/download", headers=headers) as response:
             response.raise_for_status()
-            total_size = int(response.headers.get("content-length", 0))
             with (open(main_file.name, "wb") as f):
                 for chunk in response.iter_raw():
                     bytes_written = f.write(chunk)
@@ -209,7 +208,6 @@ def get_local_variantfile(drs_obj_id, headers):
         index_file = tempfile.NamedTemporaryFile(delete=False)
         with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['index']}/download", headers=headers) as response:
             response.raise_for_status()
-            total_size = int(response.headers.get("content-length", 0))
             with (open(index_file.name, "wb") as f):
                 for chunk in response.iter_raw():
                     bytes_written = f.write(chunk)

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -5,7 +5,6 @@ import os
 import sys
 from watchdog.observers import Observer
 import watchdog.events
-import hashlib
 import re
 import datetime
 from candigv2_logging.logging import initialize, CanDIGLogger

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -38,13 +38,13 @@ def index_variants(drs_obj_id, service_headers, program):
         return {"message": f"Fastx object {drs_obj_id} stats calculated"}, 200
 
     logger.info(f"{drs_obj_id} starting indexing")
-    write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} starting indexing")
+    write_index_status(drs_obj_id, service_headers, f"starting indexing")
 
     with get_local_variantfile(drs_obj_id, service_headers) as local_variantfile:
         headers = str(local_variantfile.header).split('\n')
 
         db_variantfile = database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
-        logger.info(f"{drs_obj_id} indexed {len(headers)} headers")
+        write_index_status(drs_obj_id, service_headers, f"indexed {len(headers)} headers")
 
         response = requests.get(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj_id}", headers=service_headers)
         if response.status_code == 200:
@@ -58,7 +58,7 @@ def index_variants(drs_obj_id, service_headers, program):
             if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
                 logger.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-        logger.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
+        write_index_status(drs_obj_id, service_headers, f"indexed {len(samples)} samples in file")
 
         contigs = {}
         for contig in list(local_variantfile.header.contigs):
@@ -84,10 +84,9 @@ def index_variants(drs_obj_id, service_headers, program):
                     logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
             res = create_position(to_create)
 
-            logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+            write_index_status(drs_obj_id, service_headers, f"writing {len(res['bucket_counts'])} entries to db")
             write_pos_bucket(res, drs_obj_id)
             mark_as_indexed(drs_obj_id, service_headers)
-            logger.info(f"{drs_obj_id} indexing done")
         except Exception as e:
             raise Exception(f"({type(e)} {str(e)}) got as far as {normalized_contigs[-1]} {positions[-1]} in {drs_obj_id}")
 
@@ -170,14 +169,14 @@ def index_touch_file(file_path):
             drs_obj_id = file_parse.group(2)
             response, status_code = index_variants(drs_obj_id, service_headers, program)
             if status_code != 200:
-                write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} {response['message']}")
+                write_index_status(drs_obj_id, service_headers, f"{response['message']}")
             logger.info(response)
             os.remove(file_path)
         else:
             raise Exception(f"Format of file name is wrong: {name}")
 
     except Exception as e:
-        write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} {str(e)}")
+        write_index_status(drs_obj_id, service_headers, f"{type(e)} {str(e)}")
         os.rename(file_path, file_path.replace(INDEXING_PATH, FAILURE_PATH))
         logger.warning(f"indexing error! {type(e)} {str(e)}")
 
@@ -186,7 +185,7 @@ def write_index_status(drs_obj_id, headers, message):
     response = requests.get(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj_id}", headers=headers)
     if response.status_code == 200:
         obj = response.json()
-        obj["metadata"]["index_status"] = message
+        obj["metadata"]["index_status"] = f"{datetime.datetime.today()} {message}"
         response = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects", headers=headers, json=obj)
 
 

--- a/htsget_server/indexing.py
+++ b/htsget_server/indexing.py
@@ -13,6 +13,11 @@ from random import randint
 import requests
 from authx.auth import create_service_token
 import json
+import tempfile
+import httpx
+from pysam import VariantFile
+from contextlib import contextmanager
+
 
 logger = CanDIGLogger(__file__)
 
@@ -20,7 +25,8 @@ initialize()
 
 
 def index_variants(drs_obj_id, service_headers, program):
-    gen_obj = htsget_operations.get_pysam_obj(drs_obj_id, headers=service_headers)
+    gen_obj = htsget_operations._describe_drs_object(drs_obj_id, headers=service_headers)
+
     if gen_obj is None:
         return {"message": f"No id {drs_obj_id} exists"}, 404
     if "message" in gen_obj:
@@ -34,55 +40,56 @@ def index_variants(drs_obj_id, service_headers, program):
     logger.info(f"{drs_obj_id} starting indexing")
     write_index_status(drs_obj_id, service_headers, f"{datetime.datetime.today()} starting indexing")
 
-    headers = str(gen_obj['file'].header).split('\n')
+    with get_local_variantfile(drs_obj_id, service_headers) as local_variantfile:
+        headers = str(local_variantfile.header).split('\n')
 
-    variantfile = database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
-    logger.info(f"{drs_obj_id} indexed {len(headers)} headers")
+        db_variantfile = database.add_header_for_variantfile({'texts': headers, 'variantfile_id': drs_obj_id})
+        logger.info(f"{drs_obj_id} indexed {len(headers)} headers")
 
-    response = requests.get(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj_id}", headers=service_headers)
-    if response.status_code == 200:
-        obj = response.json()
-        if "analysis_date" not in obj["metadata"] and "analysis_date" in variantfile:
-            obj["metadata"]["analysis_date"] = variantfile["analysis_date"]
-            response = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects", headers=service_headers, json=obj)
+        response = requests.get(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj_id}", headers=service_headers)
+        if response.status_code == 200:
+            obj = response.json()
+            if "analysis_date" not in obj["metadata"] and "analysis_date" in db_variantfile:
+                obj["metadata"]["analysis_date"] = db_variantfile["analysis_date"]
+                response = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects", headers=service_headers, json=obj)
 
-    samples = list(gen_obj['file'].header.samples)
-    for sample in samples:
-        if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
-            logger.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
+        samples = list(local_variantfile.header.samples)
+        for sample in samples:
+            if database.create_sample({'id': sample, 'variantfile_id': drs_obj_id}) is None:
+                logger.warning(f"Could not add sample {sample} to variantfile {drs_obj_id}")
 
-    logger.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
+        logger.info(f"{drs_obj_id} indexed {len(samples)} samples in file")
 
-    contigs = {}
-    for contig in list(gen_obj['file'].header.contigs):
-        contigs[contig] = database.normalize_contig(contig)
+        contigs = {}
+        for contig in list(local_variantfile.header.contigs):
+            contigs[contig] = database.normalize_contig(contig)
 
-    # find first normalized contig and set the chr_prefix:
-    for raw_contig in contigs.keys():
-        if contigs[raw_contig] is not None:
-            prefix = database.get_contig_prefix(raw_contig)
-            varfile = database.set_variantfile_prefix({"variantfile_id": drs_obj_id, "chr_prefix": prefix})
-            break
+        # find first normalized contig and set the chr_prefix:
+        for raw_contig in contigs.keys():
+            if contigs[raw_contig] is not None:
+                prefix = database.get_contig_prefix(raw_contig)
+                varfile = database.set_variantfile_prefix({"variantfile_id": drs_obj_id, "chr_prefix": prefix})
+                break
 
-    positions = []
-    normalized_contigs = []
-    to_create = {'variantfile_id': drs_obj_id, 'positions': positions, 'normalized_contigs': normalized_contigs}
-    try:
-        for record in gen_obj['file'].fetch():
-            normalized_contig_id = contigs[record.contig]
-            if normalized_contig_id is not None:
-                positions.append(record.pos)
-                normalized_contigs.append(normalized_contig_id)
-            else:
-                logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
-        res = create_position(to_create)
+        positions = []
+        normalized_contigs = []
+        to_create = {'variantfile_id': drs_obj_id, 'positions': positions, 'normalized_contigs': normalized_contigs}
+        try:
+            for record in local_variantfile.fetch():
+                normalized_contig_id = contigs[record.contig]
+                if normalized_contig_id is not None:
+                    positions.append(record.pos)
+                    normalized_contigs.append(normalized_contig_id)
+                else:
+                    logger.warning(f"referenceName {record.contig} in {drs_obj_id} does not correspond to a known chromosome.")
+            res = create_position(to_create)
 
-        logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
-        write_pos_bucket(res, drs_obj_id)
-        mark_as_indexed(drs_obj_id, service_headers)
-        logger.info(f"{drs_obj_id} indexing done")
-    except Exception as e:
-        raise Exception(f"({type(e)} {str(e)}) got as far as {normalized_contigs[-1]} {positions[-1]} in {drs_obj_id}")
+            logger.info(f"{drs_obj_id} writing {len(res['bucket_counts'])} entries to db")
+            write_pos_bucket(res, drs_obj_id)
+            mark_as_indexed(drs_obj_id, service_headers)
+            logger.info(f"{drs_obj_id} indexing done")
+        except Exception as e:
+            raise Exception(f"({type(e)} {str(e)}) got as far as {normalized_contigs[-1]} {positions[-1]} in {drs_obj_id}")
 
     return {"message": f"Indexing complete for variantfile {drs_obj_id}"}, 200
 
@@ -181,6 +188,40 @@ def write_index_status(drs_obj_id, headers, message):
         obj = response.json()
         obj["metadata"]["index_status"] = message
         response = requests.post(url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects", headers=headers, json=obj)
+
+
+@contextmanager
+def get_local_variantfile(drs_obj_id, headers):
+    drs_obj = htsget_operations._describe_drs_object(drs_obj_id, headers=headers)
+
+    # download the main file
+    main_file = tempfile.NamedTemporaryFile(delete=False)
+    with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['main']}/download", headers=headers) as response:
+        response.raise_for_status()
+        total_size = int(response.headers.get("content-length", 0))
+        with (open(main_file.name, "wb") as f):
+            for chunk in response.iter_raw():
+                bytes_written = f.write(chunk)
+        main_file.close()
+
+    # download the index file
+    index_file = tempfile.NamedTemporaryFile(delete=False)
+    with httpx.stream("GET", url=f"{os.getenv("DRS_URL")}/ga4gh/drs/v1/objects/{drs_obj['index']}/download", headers=headers) as response:
+        response.raise_for_status()
+        total_size = int(response.headers.get("content-length", 0))
+        with (open(index_file.name, "wb") as f):
+            for chunk in response.iter_raw():
+                bytes_written = f.write(chunk)
+        index_file.close()
+
+    var_obj = VariantFile(main_file.name, index_filename=index_file.name)
+
+    try:
+        yield var_obj
+    finally:
+        var_obj.close()
+        os.remove(main_file.name)
+        os.remove(index_file.name)
 
 
 class IndexingHandler(watchdog.events.FileSystemEventHandler):


### PR DESCRIPTION
It seems safest to write out the S3-stored vcf files locally as tempfiles before indexing. I've deployed this as a hotfix on UHN prod and tested a file that used to fail and it indexed successfully.