### PR TITLE
Add pending and failed lists to indexer status

### DIFF
--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -5,7 +5,7 @@ from flask import send_file, Flask
 from urllib.parse import urlencode, urlparse, parse_qs
 import database
 import authz
-from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH, INDEXING_SWITCH_FILE, FAILURE_PATH
+from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, INDEXING_PATH, INDEXING_SWITCH_FILE, FAILURE_PATH
 from markupsafe import escape
 import connexion
 import variants

--- a/htsget_server/htsget_operations.py
+++ b/htsget_server/htsget_operations.py
@@ -5,7 +5,7 @@ from flask import send_file, Flask
 from urllib.parse import urlencode, urlparse, parse_qs
 import database
 import authz
-from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH, INDEXING_SWITCH_FILE
+from config import CHUNK_SIZE, HTSGET_URL, BUCKET_SIZE, PORT, INDEXING_PATH, INDEXING_SWITCH_FILE, FAILURE_PATH
 from markupsafe import escape
 import connexion
 import variants
@@ -72,8 +72,10 @@ def get_variant_service_info():
 
 
 def indexer_status():
+    if not authz.has_full_authz(connexion.request):
+        return {"message": "User is not authorized to switch indexer"}, 403
     if os.path.isfile(INDEXING_SWITCH_FILE):
-        return {"status": "ON"}, 200
+        return {"status": "ON", "pending": os.listdir(INDEXING_PATH), "failed": os.listdir(FAILURE_PATH)}, 200
     return {"status": "OFF"}, 200
 
 


### PR DESCRIPTION
Add some more keys to the return object for `GET /indexer`. Also requires full authorization to do it, since the results are sensitive.